### PR TITLE
Use non-broken HPI plugin..

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,20 @@
     </developer>
   </developers>
 
+    <build>
+        <plugins>
+             <plugin>
+            <groupId>org.jenkins-ci.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <version>1.65-SNAPSHOT</version>
+            <extensions>true</extensions>
+            <configuration>
+              <showDeprecation>true</showDeprecation>
+            </configuration>
+          </plugin>
+        </plugins>
+    </build>
+
   <!--
   <dependencies>
     <dependency>


### PR DESCRIPTION
see commit message : basically the HPI in use ends up with a circular dependency with the work I'm doing on maven-plugin.
