### PR TITLE
Job stops if PROPFILE is not found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
   -->
   
   <scm>
-    <connection>scm:git:git://github.com/jniehus/token-macro-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jniehus/token-macro-plugin.git</developerConnection>
+    <connection>scm:git:git://github.com/jenkinsci/token-macro-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/token-macro-plugin.git</developerConnection>
   </scm>
 
   <repositories>


### PR DESCRIPTION
Some jobs will not know what their token should be until runtime. In our case we are using the Build Name plugin and want to access the token's value during run-time of the job.  But unless there is a PROPFILE at the start, the plugin will crash. One solution was to checkin a placeholder PROPFILE that the script would just update but this turned out to not work since Jenkins locks this file in another process. The only approach we were able to get to work was to have the plugin look for the file before trying to read it, if it didnt exists then return some empty string or file not found, if it did exist the proceed as normal
