### PR TITLE
Fix missing method for inherited classes and fix test

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/DataBoundTokenMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/DataBoundTokenMacro.java
@@ -183,4 +183,9 @@ public abstract class DataBoundTokenMacro extends TokenMacro {
     }
 
     public abstract String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException;
+
+    @Override
+    public boolean hasNestedContent() {
+        return false;
+    }
 }


### PR DESCRIPTION
Fixed a missing override of hasNestedContent to allow child classes to correctly override. Also, changed the way that the test for the property file created the file to help with Windows locking issues.
