### PR TITLE
Address regressions in Email-ext v2.29 due to new dependency on token-macro-plugin: backslash-escaped terminators in content token string arguments no longer work; and very long content string parameters trigger StackOverflowErrors (JENKINS-14132)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/Tokenizer.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/Tokenizer.java
@@ -47,9 +47,10 @@ class Tokenizer {
     private static final String numberRegex = "-?[0-9]+(\\.[0-9]*)?";
 
     private static final String boolRegex = "(true)|(false)";
-    // Sequence of (1) not \ " CR LF and (2) \ followed by non line terminator
 
-    private static final String stringRegex = "\"([^\\\\\"\\r\\n]|(\\\\.))*\"";
+    // Sequence of (1) not \ " CR LF and (2) \ followed by (CR)LF, or not CR LF
+    // Use possessive quantifier to prevent stack overflow (see JENKINS-14132)
+    private static final String stringRegex = "\"([^\\\\\"\\r\\n]|(\\\\(?:\r?\n|.)))*+\"";
 
     private static final String valueRegex = "(" + numberRegex + ")|(" + boolRegex + ")|(" + stringRegex + ")";
 

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/TokenMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/TokenMacroTest.java
@@ -39,7 +39,32 @@ public class TokenMacroTest extends HudsonTestCase {
 
         assertEquals("{abc=[def, ghi], jkl=[true]}",TokenMacro.expand(b,listener,"${TEST_NESTED}"));
     }
-    
+
+    public void testVeryLongStringArg() throws Exception {
+        StringBuilder veryLongStringParam = new StringBuilder();
+        for (int i = 0 ; i < 500 ; ++i) {
+            veryLongStringParam.append("abc123 %_= ~");
+        }
+
+        FreeStyleProject p = createFreeStyleProject("foo");
+        FreeStyleBuild b = p.scheduleBuild2(0).get();
+
+        listener = new StreamTaskListener(System.out);
+
+        assertEquals("{arg=["+ veryLongStringParam + "]}",TokenMacro.expand(b,listener,"${TEST, arg=\"" + veryLongStringParam + "\"}"));
+    }
+
+    public void testMultilineStringArgs() throws Exception {
+        FreeStyleProject p = createFreeStyleProject("foo");
+        FreeStyleBuild b = p.scheduleBuild2(0).get();
+
+        listener = new StreamTaskListener(System.out);
+
+        assertEquals("{arg=[a \n b  \r\n c]}\n",TokenMacro.expand(b, listener, "${TEST, arg = \"a \\\n b  \\\r\n c\"}\n"));
+
+        assertEquals("${TEST, arg = \"a \n b  \r\n c\"}\n",TokenMacro.expand(b, listener, "${TEST, arg = \"a \n b  \r\n c\"}\n"));
+    }
+
     public void testEscaped() throws Exception {
         FreeStyleProject p = createFreeStyleProject("foo");
         FreeStyleBuild b = p.scheduleBuild2(0).get();


### PR DESCRIPTION
- Allow backslash-escaped terminators in content token string arguments
- JENKINS-14132: Very long content string parameter triggers a StackOverflowError

Tests included for both of the above that fail without the changes and succeed with them.
