### PR TITLE
Created Macro To Run Regular Expression Against Log Output

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/LogRegExMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/LogRegExMacro.java
@@ -1,0 +1,91 @@
+
+package org.jenkinsci.plugins.tokenmacro.impl;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.TaskListener;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+
+/**
+ * Uses a regular expression to find a single log entry and generates
+ * a new output using the capture groups from it. This is partially
+ * based on the description-setter plugin
+ * (https://github.com/jenkinsci/description-setter-plugin).
+ *
+ */
+@Extension
+public final class LogRegExMacro extends DataBoundTokenMacro {
+    private static final String MACRO_NAME = "LOG_REGEX";
+
+    @Parameter(required=true)
+    public String regex = null;
+
+    @Parameter(required=true)
+    public String replacement = null;
+
+    @Override
+    public boolean acceptsMacroName(String macroName) {
+        return macroName.equals(MACRO_NAME);
+    }
+
+    @Override
+    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
+        return readLogFile(context.getLogFile());
+    }
+
+    public String readLogFile(File file) throws IOException
+    {
+        if (regex == null) {
+            return "";
+        }
+
+        // Assume default encoding and text files
+        String line;
+        Pattern pattern = Pattern.compile(regex);
+        BufferedReader reader = new BufferedReader(new FileReader(file));
+        while ((line = reader.readLine()) != null)
+        {
+            Matcher matcher = pattern.matcher(line);
+            if (matcher.find())
+            {
+                // Match only the top-most line
+                return getTranslatedDescription(matcher);
+            }
+        }
+
+        return "";
+    }
+
+    private String getTranslatedDescription(Matcher matcher)
+    {
+        String result = replacement;
+        if (result == null) {
+            if (matcher.groupCount() == 0)
+            {
+                result = "\\0";
+            }
+            else
+            {
+                result = "\\1";
+            }
+        }
+
+        // Expand all groups: 1..Count, as well as 0 for the entire pattern
+        for (int i = matcher.groupCount(); i >= 0; i--)
+        {
+            result = result.replace(
+                "\\" + i,
+                matcher.group(i) == null ? "" : matcher.group(i));
+        }
+
+        return result;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/LogRegExMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/LogRegExMacroTest.java
@@ -1,0 +1,32 @@
+package org.jenkinsci.plugins.tokenmacro.impl;
+
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.TaskListener;
+import hudson.util.StreamTaskListener;
+import java.io.IOException;
+import org.jenkinsci.plugins.tokenmacro.*;
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.TestBuilder;
+
+public class LogRegExMacroTest extends HudsonTestCase {
+    private TaskListener listener;
+
+    public void testPropertyFromFileExpansion() throws Exception {
+        FreeStyleProject project = createFreeStyleProject("tester");
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                listener.getLogger().println("Test Property 123");
+                return true;
+            }
+        });
+        FreeStyleBuild b = project.scheduleBuild2(0).get();
+
+        listener = new StreamTaskListener(System.out);
+        assertEquals("value 123",TokenMacro.expand(b, listener, "${LOG_REGEX,regex=\"Test Property (123)\",replacement=\"value \\\\1\"}"));
+    }
+}


### PR DESCRIPTION
Consumers can now use the LOG_REGEX command to parse a build's log,
finding the first occurrence of a regular expression and replace it
with the specified value.

This can give the build-name-setter plugin some of the functionality
of its description counterpart. In fact, that plugin was an
inspiration for this feature to some degree.
