### PR TITLE
Update pom.xml with MIT license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,14 @@
     <artifactId>plugin</artifactId>
     <version>1.509.3</version>
   </parent>
+  
+  <licenses>
+    <license>
+      <name>The MIT License (MIT)</name>
+      <url>http://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
   <artifactId>token-macro</artifactId>
   <version>1.10-SNAPSHOT</version>


### PR DESCRIPTION
Thanks for your work on this plugin. We really appreciate your efforts at Swrve, but we've been unable to track down which license your plugin false under. I would have preferred to simply open an issue about this, but your repo doesn't seem to accept issues :cry:, hence this pull request. I've added the MIT license in this PR, as it seems to be used quite frequently by Jenkins plugins, although you can of course choose whichever license you like.

There's also an open Jira ticket for this here: https://issues.jenkins-ci.org/browse/JENKINS-21270.
