### PR TITLE
[WiP] Change token macro to use Run<> instead of AbstractBuild<>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.3</version>
+    <version>1.580.1</version>
   </parent>
   
   <licenses>

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/DataBoundTokenMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/DataBoundTokenMacro.java
@@ -24,7 +24,9 @@
 package org.jenkinsci.plugins.tokenmacro;
 
 import com.google.common.collect.ListMultimap;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.apache.commons.beanutils.ConvertUtils;
 
@@ -161,7 +163,8 @@ public abstract class DataBoundTokenMacro extends TokenMacro {
     }
 
     @Override
-    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
+    public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) 
+            throws MacroEvaluationException, IOException, InterruptedException {
         try {
             DataBoundTokenMacro copy = getClass().newInstance();
 
@@ -186,15 +189,20 @@ public abstract class DataBoundTokenMacro extends TokenMacro {
                     throw new MacroEvaluationException(MessageFormat.format("Parameter {0} in token {1} is required but was not specfified", e.getKey(), macroName));
             }
 
-            return copy.evaluate(context,listener,macroName);
+            return copy.evaluate(context, workspace, listener, macroName);
         } catch (InstantiationException e) {
             throw new Error(e);
         } catch (IllegalAccessException e) {
             throw new Error(e);
         }
     }
-
-    public abstract String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException;
+    
+    public abstract String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException;
+    
+    @Deprecated
+    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
+        return evaluate(context, context.getWorkspace(), listener, macroName);
+    }
 
     @Override
     public boolean hasNestedContent() {

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/AdminEmailMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/AdminEmailMacro.java
@@ -8,7 +8,8 @@ package org.jenkinsci.plugins.tokenmacro.impl;
 
 import com.google.common.collect.ListMultimap;
 import hudson.Extension;
-import hudson.model.AbstractBuild;
+import hudson.FilePath;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.Map;
@@ -31,7 +32,8 @@ public class AdminEmailMacro extends TokenMacro {
     }
 
     @Override
-    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
+    public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) 
+            throws MacroEvaluationException, IOException, InterruptedException{
         return JenkinsLocationConfiguration.get().getAdminAddress();
     }
     

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildNumberMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildNumberMacro.java
@@ -25,7 +25,8 @@ package org.jenkinsci.plugins.tokenmacro.impl;
 
 import com.google.common.collect.ListMultimap;
 import hudson.Extension;
-import hudson.model.AbstractBuild;
+import hudson.FilePath;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
@@ -44,7 +45,8 @@ public class BuildNumberMacro extends TokenMacro {
     }
 
     @Override
-    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
+    public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) 
+            throws MacroEvaluationException, IOException, InterruptedException{
         return String.valueOf(context.getNumber());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildUrlMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildUrlMacro.java
@@ -25,8 +25,9 @@ package org.jenkinsci.plugins.tokenmacro.impl;
 
 import com.google.common.collect.ListMultimap;
 import hudson.Extension;
-import hudson.model.AbstractBuild;
-import hudson.model.Hudson;
+import hudson.FilePath;
+import jenkins.model.Jenkins;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
@@ -45,7 +46,7 @@ public class BuildUrlMacro extends TokenMacro {
     }
 
     @Override
-    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
-        return Hudson.getInstance().getRootUrl() + context.getUrl();
+    public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
+        return Jenkins.getInstance().getRootUrl() + context.getUrl();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/EnvironmentVariableMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/EnvironmentVariableMacro.java
@@ -1,7 +1,10 @@
 package org.jenkinsci.plugins.tokenmacro.impl;
 
+import com.google.common.collect.ListMultimap;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.Map;
@@ -18,7 +21,12 @@ public class EnvironmentVariableMacro extends DataBoundTokenMacro {
     public String var = "";
 
     @Override
-    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName)
+    public boolean acceptsMacroName(String macroName) {
+        return macroName.equals("ENV");
+    }
+
+    @Override
+    public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName) 
             throws MacroEvaluationException, IOException, InterruptedException {
         Map<String, String> env = context.getEnvironment(listener);
         if(env.containsKey(var)){
@@ -26,10 +34,4 @@ public class EnvironmentVariableMacro extends DataBoundTokenMacro {
         }
         return "";
     }
-
-    @Override
-    public boolean acceptsMacroName(String macroName) {
-        return macroName.equals("ENV");
-    }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/PropertyFromFileMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/PropertyFromFileMacro.java
@@ -1,18 +1,21 @@
 package org.jenkinsci.plugins.tokenmacro.impl;
 
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.Callable;
-import java.io.Closeable;
-import java.io.Reader;
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.Properties;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.remoting.RoleChecker;
 
 /**
  * Expands to a property from a property file relative to the workspace root.
@@ -32,9 +35,9 @@ public class PropertyFromFileMacro extends DataBoundTokenMacro {
     }
 
     @Override
-    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
-        String root = context.getWorkspace().getRemote();
-        return context.getWorkspace().act(new ReadProperty(root,file,property));
+    public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
+        String root = workspace.getRemote();
+        return workspace.act(new ReadProperty(root,file,property));
     }
 
     private static class ReadProperty implements Callable<String,IOException> {
@@ -49,6 +52,7 @@ public class PropertyFromFileMacro extends DataBoundTokenMacro {
             this.propertyname=property;
         }
         
+        @Override
         public String call() throws IOException {
             Properties props = new Properties();
             File file = new File(root, filename);
@@ -76,6 +80,11 @@ public class PropertyFromFileMacro extends DataBoundTokenMacro {
             }
             
             return propertyValue;
+        }
+
+        @Override
+        public void checkRoles(RoleChecker rc) throws SecurityException {
+            //TODO: determine what to do here
         }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/DataBoundTokenMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/DataBoundTokenMacroTest.java
@@ -6,9 +6,11 @@
 
 package org.jenkinsci.plugins.tokenmacro;
 
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import static junit.framework.TestCase.assertEquals;
@@ -57,7 +59,7 @@ public class DataBoundTokenMacroTest {
         public String arg = "default";
 
         @Override
-        public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
+        public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
             return arg;
         }
 
@@ -81,7 +83,7 @@ public class DataBoundTokenMacroTest {
         }
         
         @Override
-        public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
+        public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
             return String.format("default = %s, arg2 = %d", arg, arg2);
         }
 

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/TokenMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/TokenMacroTest.java
@@ -1,14 +1,13 @@
 package org.jenkinsci.plugins.tokenmacro;
 
 import com.google.common.collect.ListMultimap;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.StreamTaskListener;
-import org.jvnet.hudson.test.Bug;
-import org.jvnet.hudson.test.TestExtension;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,7 +17,9 @@ import static junit.framework.Assert.fail;
 import static junit.framework.TestCase.assertEquals;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -159,7 +160,7 @@ public class TokenMacroTest {
         }
 
         @Override
-        public String evaluate(AbstractBuild<?,?> context, TaskListener listener, String macroName, Map<String,String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
+        public String evaluate(Run<?,?> context, FilePath workspace, TaskListener listener, String macroName, Map<String,String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
             return "TEST_PRIVATE";
         }
     }
@@ -171,7 +172,7 @@ public class TokenMacroTest {
         }
 
         @Override
-        public String evaluate(AbstractBuild<?,?> context, TaskListener listener, String macroName, Map<String,String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
+        public String evaluate(Run<?,?> context, FilePath workspace, TaskListener listener, String macroName, Map<String,String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
             return "TEST2_PRIVATE";
         }
     }
@@ -184,7 +185,7 @@ public class TokenMacroTest {
         }
 
         @Override
-        public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
+        public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
             return argumentMultimap.toString();
         }
     }
@@ -197,7 +198,7 @@ public class TokenMacroTest {
         }
 
         @Override
-        public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
+        public String evaluate(Run<?, ?> context, FilePath workspace, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
             return "${TEST,abc=\"def\",abc=\"ghi\",jkl=true}";
         }
 


### PR DESCRIPTION
Deprecated the older versions of the methods for evaluate and expand, added new methods that take a Run<> and FilePath for the workspace.