### PR TITLE
Fixed an NPE

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/TokenMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/TokenMacro.java
@@ -168,8 +168,13 @@ public abstract class TokenMacro implements ExtensionPoint {
         Tokenizer tokenizer = new Tokenizer(stringWithMacro);
         
         List<TokenMacro> all = new ArrayList<TokenMacro>(all());
-        if(privateTokens!=null) {
-            all.addAll( privateTokens );
+
+        if (privateTokens != null) {
+            for (TokenMacro macro : privateTokens) {
+                if (macro != null) {
+                    all.add(macro);
+                }
+            }
         }
 
         while (tokenizer.find()) {

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/TokenMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/TokenMacroTest.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.tokenmacro;
 
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
 import hudson.model.*;
 import hudson.util.StreamTaskListener;
 import org.jvnet.hudson.test.Bug;
@@ -165,6 +166,21 @@ public class TokenMacroTest {
 
         assertEquals("${TEST_NESTEDX}", TokenMacro.expand(b,listener,"${TEST_NESTEDX}",false,null));
         assertEquals("${TEST_NESTEDX,abc=\"def\",abc=\"ghi\",jkl=true}", TokenMacro.expand(b,listener,"${TEST_NESTEDX,abc=\"def\",abc=\"ghi\",jkl=true}",false,null));
+    }
+
+    @Test
+    public void testThatATokenMacroListWithANullEntryDoesNotExplode() throws Exception {
+        List<TokenMacro> badList = Lists.newLinkedList();
+        badList.add(null);
+        badList.add(new PrivateTestMacro());
+        badList.add(new PrivateTestMacro2());
+
+        FreeStyleProject p = j.createFreeStyleProject("foo");
+        FreeStyleBuild b = p.scheduleBuild2(0).get();
+
+        listener = new StreamTaskListener(System.out);
+        assertEquals("TEST_PRIVATE"+j.jenkins.getRootUrl()+"job/foo/1/TEST2_PRIVATE",
+                TokenMacro.expand(b,listener,"${TEST_PRIVATE}${BUILD_URL}${TEST2_PRIVATE}",true,badList));
     }
 
     public class PrivateTestMacro extends TokenMacro {


### PR DESCRIPTION
Hello, I recently upgraded my version of Jenkins to the newest version of Jenkins and I started seeing an NPE.

```
Nov 18, 2015 12:05:37 AM hudson.plugins.emailext.plugins.ContentBuilder transformText
SEVERE: null
java.lang.NullPointerException
    at org.jenkinsci.plugins.tokenmacro.TokenMacro.expand(TokenMacro.java:180)
    at org.jenkinsci.plugins.tokenmacro.TokenMacro.expandAll(TokenMacro.java:233)
    at hudson.plugins.emailext.plugins.ContentBuilder.transformText(ContentBuilder.java:72)
    at hudson.plugins.emailext.ExtendedEmailPublisher.getContent(ExtendedEmailPublisher.java:659)
    at hudson.plugins.emailext.ExtendedEmailPublisher.createMail(ExtendedEmailPublisher.java:538)
    at hudson.plugins.emailext.ExtendedEmailPublisher.sendMail(ExtendedEmailPublisher.java:306)
    at hudson.plugins.emailext.ExtendedEmailPublisher._perform(ExtendedEmailPublisher.java:297)
    at hudson.plugins.emailext.ExtendedEmailPublisher.perform(ExtendedEmailPublisher.java:244)
    at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
    at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:782)
    at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:723)
    at hudson.model.Build$BuildExecution.cleanUp(Build.java:195)
    at hudson.model.Run.execute(Run.java:1785)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
    at hudson.model.ResourceController.execute(ResourceController.java:98)
    at hudson.model.Executor.run(Executor.java:410)
```

I have included a test that reproduces the NPE and I added some more null checking.

Feel free to decline if you don't feel that this should be fixed in this manner.
