### PR TITLE
JENKINS-32331 Removed bottleneck synchronisation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/DataBoundTokenMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/DataBoundTokenMacro.java
@@ -24,7 +24,6 @@
 package org.jenkinsci.plugins.tokenmacro;
 
 import com.google.common.collect.ListMultimap;
-import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
 import org.apache.commons.beanutils.ConvertUtils;
@@ -37,9 +36,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
@@ -93,7 +92,7 @@ public abstract class DataBoundTokenMacro extends TokenMacro {
     private synchronized void buildMap() {
         if (setters!=null)  return;
 
-        setters = new HashMap<String, Setter>();
+        setters = new ConcurrentHashMap<String, Setter>();
         for (final Field f : getClass().getFields()) {
             final Parameter p = f.getAnnotation(Parameter.class);
             if (p !=null) {
@@ -101,7 +100,7 @@ public abstract class DataBoundTokenMacro extends TokenMacro {
                 if (StringUtils.isNotEmpty(p.alias())) {
                     name = p.alias();
                 }
-                
+
                 setters.put(name,new Setter() {
                     public Class<?> getType() {
                         return f.getType();
@@ -133,7 +132,7 @@ public abstract class DataBoundTokenMacro extends TokenMacro {
                 if (name.startsWith("set")) {
                     name = Introspector.decapitalize(name.substring(3));
                 }
-                
+
                 if (StringUtils.isNotEmpty(p.alias())) {
                     name = p.alias();
                 }

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/DataBoundTokenMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/DataBoundTokenMacro.java
@@ -162,7 +162,7 @@ public abstract class DataBoundTokenMacro extends TokenMacro {
     }
 
     @Override
-    public synchronized String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
+    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
         try {
             DataBoundTokenMacro copy = getClass().newInstance();
 


### PR DESCRIPTION
Hi,

In the context of trying to solve the JENKINS-32331 issue, I propose to remove the `synchronized` modifier from the `org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro#evaluate(hudson.model.AbstractBuild<?,?>, hudson.model.TaskListener, java.lang.String, java.util.Map<java.lang.String,java.lang.String>, com.google.common.collect.ListMultimap<java.lang.String,java.lang.String>)` method. This modifier had been introduced to fix some Findbugs issues but this causes a bottleneck issue in case of heavy load.

The scenario, which I cannot reproduce using a unit test, but very well in our production environment, is the following.

If the underlying token macro implementation is very long to resolve its value (like for the Build Failure Analyser, when a complete log file must be analysed), we have a global lock and many builds will wait for other builds to complete their own resolution. 

In our situation (more than 2500 jobs), in case of many simultaneous failures, this can cause a very severe bottleneck.

This bottleneck can be observed in real time using `jstack` and the lock on the `synchronized` method is very clear.

When looking at the code, we really need the synchronisation in two locations: the `buildMap` and the `setters` map itself should be synchronised (missing in the current PR - will add it later).

I'd like to discuss this issue further, to see if my analysis is correct.

Best regards,
Damien.