### PR TITLE
Help is updated for CHANGES Macros.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/AbstractChangesSinceMacro/help.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/AbstractChangesSinceMacro/help.groovy
@@ -17,6 +17,12 @@ dd {
       }
       p(_("Defaults to ") + my.defaultFormatValue)
     }
+    dt("changesFormat")
+    dd() {
+      span(_("For each change in a build. See \${CHANGES_SINCE_LAST_BUILD} for placeholders."))
+    }
   }
-  span("See additional documentation on \${BUILD_CHANGES} token for showPaths, format and pathFormat parameters")
+  span("Following Parameters are also supported: " +
+          "showPaths, pathFormat, showDependencies, dateFormat, regex, replace, default. " +
+          "See \${CHANGES_SINCE_LAST_BUILD} details.")
 }

--- a/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacro/help.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacro/help.groovy
@@ -38,5 +38,8 @@ dd() {
     dd(_("A regular expression."))
     dt("replace")
     dd(_("A replacement for all sub-strings of the change message that match the given regular expression."))
+    dt("default")
+    dd(_("Message to use when no changes are detected. " +
+            "Defaults to \"No changes\\n\""))
   }
 }


### PR DESCRIPTION
* 'default' parameter is mention in the documentation of the
  ChangesSinceLastBuildMacro;
* Parameters of ChangesSinceLast(Successful|Unstable)BuildMacro are
  made more explicit. Vague reference is replaced with a list of all the
  available parameters.