### PR TITLE
Fix the Build Log Excerpt Macro Start/End Order

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogExcerptMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogExcerptMacro.java
@@ -76,9 +76,12 @@ public class BuildLogExcerptMacro extends DataBoundTokenMacro {
                 started = true;
                 continue;
             }
-            if (endPattern.matcher(line).matches()) break;
 
-            if (started) buffer.append(line).append('\n');
+            if (started) {
+            	if (endPattern.matcher(line).matches()) break;
+            	
+            	buffer.append(line).append('\n');
+            }
         }
         return buffer.toString();
     }

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogExcerptMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogExcerptMacroTest.java
@@ -67,5 +67,19 @@ public class BuildLogExcerptMacroTest {
 
         assertEquals("7\n8\n9\n", result);
     }
+    
+    @Test
+    public void testGetContent_regexpStartEndTagsEndBeforeStart()
+    		throws Exception {
+    	AbstractBuild build = mock(AbstractBuild.class);
+    	when(build.getLogReader()).thenReturn(new StringReader("1\n2\nSTOP3\n4\n5\nTEST STARTED\n7\n8\n9\nTEST STOPED\n10\n11\n12\n"));
+    	
+    	buildLogExcerptMacro.start = ".*START.*";
+    	buildLogExcerptMacro.end = ".*STOP.*";
+    	
+    	final String result = buildLogExcerptMacro.evaluate(build, listener, BuildLogExcerptMacro.MACRO_NAME);
+    	
+    	assertEquals("7\n8\n9\n", result);
+    }
 }
 


### PR DESCRIPTION
The current version of the code has an issue when the `end` pattern is
matched before the `start` pattern was found - it simply stops parsing
the log file. This is an issue in case the `end` pattern appears in the
log multiple times (including before the `start` pattern), e.g.

```
Log 1
Log 2
sleep 5
Log 3
Log 4
Run Test
Log 5
Log 6
sleep 5
Log 7
Log 8
```

If I use the following macro:

```
${BUILD_LOG_EXCERPT, start="Run Test", end="sleep 5"}
```

then the current version of the code prints an empty excerpt, since it
stops evaluating the log when it finds the first occurence of `sleep 5`.
This feels strange, and caused me a couple of lost hours, since I was
trying to figure out why it didn't print anything. Looking at the code,
I found this issue, and have made a small change that ensures that the
`end` pattern is only checked once the `start` pattern has been found.

I hope this is fine, but to me it makes a lot more sense like that. I've
also added a unit test to verify that the fix works.