### PR TITLE
[JENKINS-40681] Increase baseline version. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <properties>
-    <jenkins.version>1.642.2</jenkins.version>
+    <jenkins.version>1.642.3</jenkins.version>
     <java.level>7</java.level>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -25,8 +25,8 @@
   <version>2.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Token Macro Plugin</name>
-
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Token+Macro+Plugin</url>
+  <description>This plugin adds reusable macro expansion capability for other plugins to use.</description>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/Token+Macro+Plugin</url>
 
   <developers>
     <developer>


### PR DESCRIPTION
[JENKINS-40681](https://issues.jenkins-ci.org/browse/JENKINS-40681)

- Increased baseline version to 1.642.3 as Workflow plugins have it as baseline.
- Included description and https for URL in POM.

@reviewbybees 