### PR TITLE
[JENKINS-46361] Solves the immediate symptoms caused by Jackson overlap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,6 @@
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-aggregator</artifactId>
-      <version>2.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
       <version>2.7</version>
     </dependency>
@@ -87,9 +82,38 @@
       <artifactId>json-path</artifactId>
       <version>2.1.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.0</version>
+    </dependency>
 
 
     <!-- Test Deps -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>


### PR DESCRIPTION
[JENKINS-46361](https://issues.jenkins-ci.org/browse/JENKINS-46361)

But I suspect there could still be problems for docker-plugin users in
general since pipeline-stage-view is actually where the jackson
dependencies were coming from and that's *probably* installed in most
cases anyway. So this may not actually fix existing users, unless they
uninstall pipeline-stage-view.

cc @reviewbybees