### PR TITLE
Bumped json-path version to 2.4.0 to solve dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.33</version>
+    <version>2.35</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,10 +93,6 @@
           <groupId>org.ow2.asm</groupId>
           <artifactId>asm</artifactId>
         </exclusion>
-        <exclusion> <!-- inlines it anyway, no need to bundle a duplicate copy (but note that licenses.xml will be incomplete) -->
-          <groupId>net.minidev</groupId>
-          <artifactId>accessors-smart</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.1.0</version>
+      <version>2.4.0</version>
       <exclusions>
         <exclusion> <!-- Note that json-smart *also* bundles ASM 5 inline, which we cannot do anything about. Bad form! -->
           <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
Hi,
ZeroTurnaround uses a custom plugin for updating AWS ECS task definitions
https://github.com/zeroturnaround/aws-ecs-deploy-jenkins-plugin
and after updating Token Macro to version >2.0, the following exception broke our flow:
```
com.jayway.jsonpath.InvalidPathException: Could not compile inline filter : [?(@.name == "app")]
18:01:57 	at com.jayway.jsonpath.internal.filter.FilterCompiler.compile(FilterCompiler.java:47)
...
18:01:57 	at com.jayway.jsonpath.internal.JsonContext.set(JsonContext.java:201)
18:01:57 	at com.zeroturnaround.jenkins.plugin.ecs.deploy.steps.RegisterTaskDefinitionStep.perform(RegisterTaskDefinitionStep.java:69)
18:01:57 	at com.zeroturnaround.jenkins.plugin.ecs.deploy.AWSECSPublisher.perform(AWSECSPublisher.java:77)
```
aws-ecs-deploy-jenkins-plugin depends on both token-macro and json-path (2.2.0+) but for some reason older version of json-path is taken from token-macro which does not support such filter.