### PR TITLE
Update for java11 readiness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <properties>
-    <jenkins.version>2.62</jenkins.version>
+    <jenkins.version>2.121.3</jenkins.version>
     <java.level>8</java.level>
     <findbugs.failOnError>false</findbugs.failOnError> <!-- TODO fix the warnings instead -->
     <workflow-step-api.version>2.14</workflow-step-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <jenkins.version>2.62</jenkins.version>
-    <java.level>7</java.level>
+    <java.level>8</java.level>
     <findbugs.failOnError>false</findbugs.failOnError> <!-- TODO fix the warnings instead -->
     <workflow-step-api.version>2.14</workflow-step-api.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.2</version>
+    <version>3.39</version>
     <relativePath />
   </parent>
 
@@ -112,7 +112,13 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.27</version>
+      <version>2.30</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId> <!-- RequireUpperBoundDeps fix -->
+      <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -149,7 +155,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>2.17</version>
+      <version>3.1</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacroTest.java
@@ -71,7 +71,7 @@ public class ChangesSinceLastBuildMacroTest {
 
         String content = changesSinceLastBuildMacro.evaluate(currentBuild, listener, ChangesSinceLastBuildMacro.MACRO_NAME);
 
-        // Java 9 changed the SHORT date format...
+        // Java 9 changed the SHORT date format... https://www.oracle.com/technetwork/java/javase/9-relnote-issues-3704069.html#JDK-8008577
         assertTrue(content.matches("Oct 21, 2013,? 7:39:00 PM"));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacroTest.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -70,7 +71,8 @@ public class ChangesSinceLastBuildMacroTest {
 
         String content = changesSinceLastBuildMacro.evaluate(currentBuild, listener, ChangesSinceLastBuildMacro.MACRO_NAME);
 
-        assertEquals("Oct 21, 2013 7:39:00 PM", content);
+        // Java 9 changed the SHORT date format...
+        assertTrue(content.matches("Oct 21, 2013,? 7:39:00 PM"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastSuccessfulBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastSuccessfulBuildMacroTest.java
@@ -147,6 +147,7 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
         String contentStr = content.evaluate(currentBuild, listener, ChangesSinceLastSuccessfulBuildMacro.MACRO_NAME);
 
         // Date format changed in Java 9, so we have to accomodate the potential additional comma
+        // See https://www.oracle.com/technetwork/java/javase/9-relnote-issues-3704069.html#JDK-8008577
         Assert.assertTrue(contentStr.matches(
                 "Changes for Build #41\n" + "Oct 21, 2013,? 7:39:00 PM\n" + "Changes for Build #42\n" + "Oct 21, 2013,? 7:39:00 PM\n"));
     }

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastSuccessfulBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastSuccessfulBuildMacroTest.java
@@ -146,7 +146,9 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
 
         String contentStr = content.evaluate(currentBuild, listener, ChangesSinceLastSuccessfulBuildMacro.MACRO_NAME);
 
-        Assert.assertEquals("Changes for Build #41\n" + "Oct 21, 2013 7:39:00 PM\n" + "Changes for Build #42\n" + "Oct 21, 2013 7:39:00 PM\n", contentStr);
+        // Date format changed in Java 9, so we have to accomodate the potential additional comma
+        Assert.assertTrue(contentStr.matches(
+                "Changes for Build #41\n" + "Oct 21, 2013,? 7:39:00 PM\n" + "Changes for Build #42\n" + "Oct 21, 2013,? 7:39:00 PM\n"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastUnstableBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastUnstableBuildMacroTest.java
@@ -147,6 +147,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
         String contentStr = content.evaluate(currentBuild, listener, ChangesSinceLastUnstableBuildMacro.MACRO_NAME);
 
         // Date format changed in Java 9, so we have to accomodate the potential additional comma
+        // See https://www.oracle.com/technetwork/java/javase/9-relnote-issues-3704069.html#JDK-8008577
         Assert.assertTrue(contentStr.matches(
                 "Changes for Build #41\n" + "Oct 21, 2013,? 7:39:00 PM\n" + "Changes for Build #42\n" + "Oct 21, 2013,? 7:39:00 PM\n"));
     }

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastUnstableBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastUnstableBuildMacroTest.java
@@ -146,7 +146,9 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         String contentStr = content.evaluate(currentBuild, listener, ChangesSinceLastUnstableBuildMacro.MACRO_NAME);
 
-        Assert.assertEquals("Changes for Build #41\n" + "Oct 21, 2013 7:39:00 PM\n" + "Changes for Build #42\n" + "Oct 21, 2013 7:39:00 PM\n", contentStr);
+        // Date format changed in Java 9, so we have to accomodate the potential additional comma
+        Assert.assertTrue(contentStr.matches(
+                "Changes for Build #41\n" + "Oct 21, 2013,? 7:39:00 PM\n" + "Changes for Build #42\n" + "Oct 21, 2013,? 7:39:00 PM\n"));
     }
 
     @Test


### PR DESCRIPTION
The core goal here was to fix a failure detected on Java 11 through PCT runs.

Had to bump a few things around to get it running. 

This should also fix #33 though it's hard to be sure, given it's a bit of a chicken-and-egg issue.