### PR TITLE
Java 11 readiness: use recommended build configurations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,4 @@
 buildPlugin(
     failFast: false,
-    configurations: [
-        [ platform: 'linux', jdk: "8", jenkins: null ],
-        [ platform: 'windows', jdk: "8", jenkins: null ],
-        [ platform: 'linux', jdk: "11", jenkins: "2.164", javaLevel: "8" ],
-        [ platform: 'windows', jdk: "11", jenkins: "2.164", javaLevel: "8" ],
-    ]
+    configurations: buildPlugin.recommendedConfigurations()
 )


### PR DESCRIPTION
Making sure this plugin is constantly checked both building with JDK8 and JDK11.

This goes with the Jenkins Java 11 General Availability announcement made back in March, and we're making a pass to check plugins are looking good on a JDK11.

https://jenkins.io/blog/2019/03/11/let-s-celebrate-java-11-support/

([to understand the Jenkinsfile content](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime))

@jenkinsci/java11-support 