### PR TITLE
If token transformation exceeds input length exception message provides details

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/transform/SubstringTransform.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/transform/SubstringTransform.java
@@ -36,7 +36,9 @@ public class SubstringTransform extends Transform {
             }
 
             if (offset + length > input.length()) {
-                throw new MacroEvaluationException("");
+                throw new MacroEvaluationException(
+                    String.format("Incorrect offset or length: input length is %d and offset end is %d",
+                                  input.length(), offset + length));
             }
 
             input = input.substring(offset, offset+length);


### PR DESCRIPTION
I was trying to perform macro `${BUILD_NUMBER:1:1}` for the build number `3` and as the result I got the exception without information what went wrong. Going over stacktrace allows me to find the reason of my mistake

```
org.jenkinsci.plugins.tokenmacro.MacroEvaluationException:
        at org.jenkinsci.plugins.tokenmacro.transform.SubstringTransform.transform(SubstringTransform.java:39)
        at org.jenkinsci.plugins.tokenmacro.Parser.processToken(Parser.java:350)
        at org.jenkinsci.plugins.tokenmacro.Action$KiHW1UeqOdqAwZul.run(Unknown Source)
        at org.parboiled.matchers.ActionMatcher.match(ActionMatcher.java:96)
        at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
        at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
        at org.parboiled.matchers.SequenceMatcher.match(SequenceMatcher.java:46)
        at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
        at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
        at org.parboiled.matchers.FirstOfMatcher.match(FirstOfMatcher.java:41)
        at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
        at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
        at org.parboiled.matchers.FirstOfMatcher.match(FirstOfMatcher.java:41)
        at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
        at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
        at org.parboiled.matchers.ZeroOrMoreMatcher.match(ZeroOrMoreMatcher.java:39)
        at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
        at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
        at org.parboiled.matchers.SequenceMatcher.match(SequenceMatcher.java:46)
        at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
        at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
        at org.parboiled.parserunners.BasicParseRunner.run(BasicParseRunner.java:72)
        at org.parboiled.parserunners.ReportingParseRunner.runBasicMatch(ReportingParseRunner.java:86)
        at org.parboiled.parserunners.ReportingParseRunner.run(ReportingParseRunner.java:66)
        at org.parboiled.parserunners.AbstractParseRunner.run(AbstractParseRunner.java:81)
        at org.parboiled.parserunners.AbstractParseRunner.run(AbstractParseRunner.java:76)
        at org.jenkinsci.plugins.tokenmacro.Parser.process(Parser.java:85)
        at org.jenkinsci.plugins.tokenmacro.Parser.process(Parser.java:74)
        at org.jenkinsci.plugins.tokenmacro.TokenMacro.expand(TokenMacro.java:199)
        at org.jenkinsci.plugins.tokenmacro.TokenMacro.expandAll(TokenMacro.java:237)
        at org.jenkinsci.plugins.tokenmacro.TokenMacro.expandAll(TokenMacro.java:207)
        at pl.damianszczepanik.jenkins.buildhistorymanager.model.conditions.TokenMacroCondition.matches(TokenMacroCondition.java:54)
        at pl.damianszczepanik.jenkins.buildhistorymanager.model.Rule.validateConditions(Rule.java:86)
        at pl.damianszczepanik.jenkins.buildhistorymanager.BuildHistoryDiscarder.perform(BuildHistoryDiscarder.java:56)
        at hudson.model.Job.logRotate(Job.java:468)
        at hudson.model.Run.execute(Run.java:1917)
        at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
        at hudson.model.ResourceController.execute(ResourceController.java:97)
        at hudson.model.Executor.run(Executor.java:427)
```