### PR TITLE
JENKINS-61110: Adding support for a new parameter truncTailLine for BUILD_LOG macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ work
 .idea
 
 .vscode/
+*.sw*
+tags
+ID


### PR DESCRIPTION
The new parameter will facilitate removal of a specified number of lines from the tail of the log. This is useful to focus on a specific section of the log by removing lines from the tail that may not be useful (e.g., boilerplate messages that always exist).