### PR TITLE
JENKINS-60999: Add support for a new parameter tailMaxCount for BUILD_LOG_REGEX token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,4 @@
+ID
+tags
+.*.sw*
 target
-work
-*.iml
-*.ipr
-*.iws
-.project
-.classpath
-.settings
-.idea
-
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
+target
+work
+*.iml
+*.ipr
+*.iws
+.project
+.classpath
+.settings
+.idea
+
+.vscode/
 ID
 tags
 .*.sw*
-target

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang.StringEscapeUtils;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -164,7 +165,7 @@ public class BuildLogRegexMacro extends DataBoundTokenMacro {
         escapeHtml = asHtml || escapeHtml;
 
         final Pattern pattern = Pattern.compile(regex);
-        List<String> matchResults = new LinkedList<>();
+        List<String> matchResults = new ArrayList<>();
         Stack<Pair<Integer, Integer>> preRanges = new Stack<>();
         int numLinesTruncated = 0;
         int numMatches = 0;

--- a/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro/help.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro/help.groovy
@@ -18,8 +18,12 @@ dd() {
          "Defaults to 0."))
   
     dt("maxMatches")
-    dd(_("The maximum number of matches to include. If 0, all matches will be included. " +
+    dd(_("The maximum number of matches to include from the head of the log. If 0, all matches will be included. " +
          "Defaults to 0."))
+  
+    dt("maxTailMatches")
+    dd(_("The maximum number of matches to include from the tail of the log. When combined with maxMatches, it further limits the matches to the tail end of matched results. " +
+         "If 0, all matches will be included. Defaults to 0."))
 
     dt("showTruncatedLines")
     dd(_("If true, include [...truncated ### lines...] lines. " +
@@ -41,5 +45,8 @@ dd() {
   
     dt("defaultValue")
     dd(_("This value will be used if nothing is replaced."))
+  
+    dt("greedy")
+    dd(_("When false and maxMatches is non-zero it causes more conservative addition of results when used with other parameters such as linesBefore and linesAfter"))
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacroTest.java
@@ -28,6 +28,12 @@ public class BuildLogRegexMacroTest {
         build = mock(AbstractBuild.class);
     }
 
+    private void mockLogReaderWithSimpleErrorLog()
+            throws Exception {
+        when(build.getLogReader()).thenReturn(new StringReader(
+                "1\n2\n3\n4\n5\n6 ERROR\n7\n8\n9 ERROR\n10\n11\n12\n13\n14\n15\n16\n17\n18 ERROR\n19\n20\n21\n22\n23\n"));
+    }
+
     @Test
     public void testGetContent_emptyBuildLogShouldStayEmpty()
             throws Exception {
@@ -41,8 +47,7 @@ public class BuildLogRegexMacroTest {
     @Test
     public void testGetContent_matchedLines()
             throws Exception {
-        when(build.getLogReader()).thenReturn(new StringReader(
-                "1\n2\n3\n4\n5\n6 ERROR\n7\n8\n9 ERROR\n10\n11\n12\n13\n14\n15\n16\n17\n18 ERROR\n19\n20\n21\n22\n23\n"));
+        mockLogReaderWithSimpleErrorLog();
         buildLogRegexMacro.showTruncatedLines = false;
 
         final String result = buildLogRegexMacro.evaluate(build, listener, BuildLogRegexMacro.MACRO_NAME);
@@ -51,10 +56,58 @@ public class BuildLogRegexMacroTest {
     }
 
     @Test
+    public void testGetContent_matchedLines_with_maxMatches()
+            throws Exception {
+        mockLogReaderWithSimpleErrorLog();
+        buildLogRegexMacro.showTruncatedLines = false;
+        buildLogRegexMacro.maxMatches = 1;
+
+        final String result = buildLogRegexMacro.evaluate(build, listener, BuildLogRegexMacro.MACRO_NAME);
+
+        assertEquals("6 ERROR\n", result);
+    }
+
+    @Test
+    public void testGetContent_matchedLines_when_not_greedy_with_default_maxMatches()
+            throws Exception {
+        mockLogReaderWithSimpleErrorLog();
+        buildLogRegexMacro.showTruncatedLines = false;
+        buildLogRegexMacro.greedy = false;
+
+        final String result = buildLogRegexMacro.evaluate(build, listener, BuildLogRegexMacro.MACRO_NAME);
+
+        assertEquals("6 ERROR\n9 ERROR\n18 ERROR\n", result);
+    }
+
+    @Test
+    public void testGetContent_matchedLines_with_maxTailMatches()
+            throws Exception {
+        mockLogReaderWithSimpleErrorLog();
+        buildLogRegexMacro.showTruncatedLines = false;
+        buildLogRegexMacro.maxTailMatches = 1;
+
+        final String result = buildLogRegexMacro.evaluate(build, listener, BuildLogRegexMacro.MACRO_NAME);
+
+        assertEquals("18 ERROR\n", result);
+    }
+
+    @Test
+    public void testGetContent_matchedLines_with_maxMatches_and_maxTailMatches()
+            throws Exception {
+        mockLogReaderWithSimpleErrorLog();
+        buildLogRegexMacro.showTruncatedLines = false;
+        buildLogRegexMacro.maxMatches = 2;
+        buildLogRegexMacro.maxTailMatches = 1;
+
+        final String result = buildLogRegexMacro.evaluate(build, listener, BuildLogRegexMacro.MACRO_NAME);
+
+        assertEquals("9 ERROR\n", result);
+    }
+
+    @Test
     public void testGetContent_truncatedAndMatchedLines()
             throws Exception {
-        when(build.getLogReader()).thenReturn(new StringReader(
-                "1\n2\n3\n4\n5\n6 ERROR\n7\n8\n9 ERROR\n10\n11\n12\n13\n14\n15\n16\n17\n18 ERROR\n19\n20\n21\n22\n23\n"));
+        mockLogReaderWithSimpleErrorLog();
 
         final String result = buildLogRegexMacro.evaluate(build, listener, BuildLogRegexMacro.MACRO_NAME);
 
@@ -64,8 +117,7 @@ public class BuildLogRegexMacroTest {
     @Test
     public void testGetContent_truncatedMatchedAndContextLines()
             throws Exception {
-        when(build.getLogReader()).thenReturn(new StringReader(
-                "1\n2\n3\n4\n5\n6 ERROR\n7\n8\n9 ERROR\n10\n11\n12\n13\n14\n15\n16\n17\n18 ERROR\n19\n20\n21\n22\n23\n"));
+        mockLogReaderWithSimpleErrorLog();
         buildLogRegexMacro.linesBefore = 3;
         buildLogRegexMacro.linesAfter = 3;
         final String result = buildLogRegexMacro.evaluate(build, listener, BuildLogRegexMacro.MACRO_NAME);
@@ -76,8 +128,7 @@ public class BuildLogRegexMacroTest {
     @Test
     public void testGetContent_matchedAndContextLines()
             throws Exception {
-        when(build.getLogReader()).thenReturn(new StringReader(
-                "1\n2\n3\n4\n5\n6 ERROR\n7\n8\n9 ERROR\n10\n11\n12\n13\n14\n15\n16\n17\n18 ERROR\n19\n20\n21\n22\n23\n"));
+        mockLogReaderWithSimpleErrorLog();
         buildLogRegexMacro.showTruncatedLines = false;
         buildLogRegexMacro.linesBefore = 3;
         buildLogRegexMacro.linesAfter = 3;
@@ -89,8 +140,7 @@ public class BuildLogRegexMacroTest {
     @Test
     public void testGetContent_truncatedMatchedAndContextLinesAsHtml()
             throws Exception {
-        when(build.getLogReader()).thenReturn(new StringReader(
-                "1\n2\n3\n4\n5\n6 ERROR\n7\n8\n9 ERROR\n10\n11\n12\n13\n14\n15\n16\n17\n18 ERROR\n19\n20\n21\n22\n23\n"));
+        mockLogReaderWithSimpleErrorLog();
         buildLogRegexMacro.matchedLineHtmlStyle = "color: red";
         buildLogRegexMacro.linesBefore = 3;
         buildLogRegexMacro.linesAfter = 3;
@@ -102,8 +152,7 @@ public class BuildLogRegexMacroTest {
     @Test
     public void testGetContent_matchedAndContextLinesAsHtml()
             throws Exception {
-        when(build.getLogReader()).thenReturn(new StringReader(
-                "1\n2\n3\n4\n5\n6 ERROR\n7\n8\n9 ERROR\n10\n11\n12\n13\n14\n15\n16\n17\n18 ERROR\n19\n20\n21\n22\n23\n"));
+        mockLogReaderWithSimpleErrorLog();
         buildLogRegexMacro.matchedLineHtmlStyle = "color: red";
         buildLogRegexMacro.linesBefore = 3;
         buildLogRegexMacro.linesAfter = 3;


### PR DESCRIPTION
Included a fix (and test cases) for a edge case scenario of using `greedy=false` with default `maxCount`. Also added missing documentation for `greedy`.