### PR TITLE
Rethrow Errors instead of polluting expansion

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/Parser.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/Parser.java
@@ -86,7 +86,7 @@ public class Parser extends BaseParser<Object> {
         } catch(Exception e) {
             if(e.getCause() instanceof MacroEvaluationException)
                 throw (MacroEvaluationException)e.getCause();
-            throw MacroEvaluationException("Error processing tokens", e);
+            throw new MacroEvaluationException("Error processing tokens", e);
         }
 
         return p.output.toString();

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/Parser.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/Parser.java
@@ -86,7 +86,7 @@ public class Parser extends BaseParser<Object> {
         } catch(Exception e) {
             if(e.getCause() instanceof MacroEvaluationException)
                 throw (MacroEvaluationException)e.getCause();
-            return String.format("Error processing tokens: %s", e.getMessage());
+            throw MacroEvaluationException("Error processing tokens", e);
         }
 
         return p.output.toString();


### PR DESCRIPTION
Instead of replacing the expansion with Error message, the Error 
should be rethrown packaged as a MacroEvaluationException.