### PR TITLE
Fix maven enforcer issues for downstream components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,33 +66,16 @@
       <artifactId>workflow-step-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-      <version>9.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-tree</artifactId>
-      <version>9.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-analysis</artifactId>
-      <version>9.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-util</artifactId>
-      <version>9.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.parboiled</groupId>
       <artifactId>parboiled-java</artifactId>
       <version>1.3.1</version>
+      <exclusions>
+        <!-- asm is provided by Jenkins core -->
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION
This prevented me from updating token-macro in a new bom line I'm creating

See https://github.com/jenkinsci/token-macro-plugin/pull/70/files#r567389865

cc @slide 