### PR TITLE
JENKINS-66018: Add a maxLineLength parameter for BUILD_LOG_REGEX and BUILD_LOG

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMacro.java
@@ -70,7 +70,7 @@ public class BuildLogMacro extends DataBoundTokenMacro {
             int nLinesToEval = lines.size() - truncTailLines;
             for (int i = 0; i < nLinesToEval; ++i) {
                 String line = lines.get(i);
-                if (maxLineLength != 0 && line.length() > maxLineLength) {
+                if (maxLineLength != MAX_LINE_LENGTH_DEFAULT_VALUE && line.length() > maxLineLength) {
                     line = line.substring(0, maxLineLength) + "...";
                 }
                 if (escapeHtml) {

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMacro.java
@@ -24,6 +24,7 @@ public class BuildLogMacro extends DataBoundTokenMacro {
     public static final String MACRO_NAME = "BUILD_LOG";
 
     public static final int MAX_LINES_DEFAULT_VALUE = 250;
+    public static final int MAX_LINE_LENGTH_DEFAULT_VALUE = 0;
 
     @Parameter
     public int maxLines = MAX_LINES_DEFAULT_VALUE;
@@ -33,6 +34,9 @@ public class BuildLogMacro extends DataBoundTokenMacro {
 
     @Parameter
     public boolean escapeHtml = false;
+
+    @Parameter
+    public int maxLineLength = MAX_LINE_LENGTH_DEFAULT_VALUE;
 
     @Override
     public boolean acceptsMacroName(String macroName) {
@@ -66,6 +70,9 @@ public class BuildLogMacro extends DataBoundTokenMacro {
             int nLinesToEval = lines.size() - truncTailLines;
             for (int i = 0; i < nLinesToEval; ++i) {
                 String line = lines.get(i);
+                if (maxLineLength != 0 && line.length() > maxLineLength) {
+                    line = line.substring(0, maxLineLength) + "...";
+                }
                 if (escapeHtml) {
                     line = StringEscapeUtils.escapeHtml(line);
                 }

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro.java
@@ -95,7 +95,7 @@ public class BuildLogRegexMacro extends DataBoundTokenMacro {
     }
 
     private void appendContextLine(List<String> matchResults, String line, boolean escapeHtml) {
-        if (maxLineLength != 0 && line.length() > maxLineLength) {
+        if (maxLineLength != MAX_LINE_LENGTH_DEFAULT_VALUE && line.length() > maxLineLength) {
             line = line.substring(0, maxLineLength) + "...";
         }
         if (escapeHtml) {
@@ -105,7 +105,7 @@ public class BuildLogRegexMacro extends DataBoundTokenMacro {
     }
 
     private void appendMatchedLine(List<String> matchResults, String line, boolean escapeHtml, String style, boolean addNewline) {
-        if (maxLineLength != 0 && line.length() > maxLineLength) {
+        if (maxLineLength != MAX_LINE_LENGTH_DEFAULT_VALUE && line.length() > maxLineLength) {
             line = line.substring(0, maxLineLength) + "...";
         }
         if (escapeHtml) {

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro.java
@@ -34,11 +34,12 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 public class BuildLogRegexMacro extends DataBoundTokenMacro {
 
     public static final String MACRO_NAME = "BUILD_LOG_REGEX";
-    private static final int LINES_BEFORE_DEFAULT_VALUE = 0;
-    private static final int LINES_AFTER_DEFAULT_VALUE = 0;
-    private static final int MAX_MATCHES_DEFAULT_VALUE = 0;
-    private static final int MAX_TAIL_MATCHES_DEFAULT_VALUE = 0;
-    private static final int MAX_LINE_LENGTH_DEFAULT_VALUE = 0;
+    public static final int LINES_BEFORE_DEFAULT_VALUE = 0;
+    public static final int LINES_AFTER_DEFAULT_VALUE = 0;
+    public static final int MAX_MATCHES_DEFAULT_VALUE = 0;
+    public static final int MAX_TAIL_MATCHES_DEFAULT_VALUE = 0;
+    public static final int MAX_LINE_LENGTH_DEFAULT_VALUE = 0;
+
     @Parameter
     public String regex = "(?i)\\b(error|exception|fatal|fail(ed|ure)|un(defined|resolved))\\b";
     @Parameter

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro.java
@@ -38,6 +38,7 @@ public class BuildLogRegexMacro extends DataBoundTokenMacro {
     private static final int LINES_AFTER_DEFAULT_VALUE = 0;
     private static final int MAX_MATCHES_DEFAULT_VALUE = 0;
     private static final int MAX_TAIL_MATCHES_DEFAULT_VALUE = 0;
+    private static final int MAX_LINE_LENGTH_DEFAULT_VALUE = 0;
     @Parameter
     public String regex = "(?i)\\b(error|exception|fatal|fail(ed|ure)|un(defined|resolved))\\b";
     @Parameter
@@ -62,6 +63,8 @@ public class BuildLogRegexMacro extends DataBoundTokenMacro {
     public boolean greedy = true;
     @Parameter
     public int maxTailMatches = MAX_TAIL_MATCHES_DEFAULT_VALUE;
+    @Parameter
+    public int maxLineLength = MAX_LINE_LENGTH_DEFAULT_VALUE;
 
     @Override
     public boolean acceptsMacroName(String macroName) {
@@ -91,6 +94,9 @@ public class BuildLogRegexMacro extends DataBoundTokenMacro {
     }
 
     private void appendContextLine(List<String> matchResults, String line, boolean escapeHtml) {
+        if (maxLineLength != 0 && line.length() > maxLineLength) {
+            line = line.substring(0, maxLineLength) + "...";
+        }
         if (escapeHtml) {
             line = StringEscapeUtils.escapeHtml(line);
         }
@@ -98,6 +104,9 @@ public class BuildLogRegexMacro extends DataBoundTokenMacro {
     }
 
     private void appendMatchedLine(List<String> matchResults, String line, boolean escapeHtml, String style, boolean addNewline) {
+        if (maxLineLength != 0 && line.length() > maxLineLength) {
+            line = line.substring(0, maxLineLength) + "...";
+        }
         if (escapeHtml) {
             line = StringEscapeUtils.escapeHtml(line);
         }

--- a/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMacro/help.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMacro/help.groovy
@@ -7,5 +7,9 @@ dd() {
   
     dt("escapeHtml")
     dd(_("If true, HTML is escape. Defaults to false."))
+
+    dt("maxLineLength")
+    dd(_("A maximum length for log lines. When lines are longer than the specified value, they are truncated and a \"...\" marker is appended at the end. " +
+         "If 0, no truncation is done. Defaults to 0."))
   }
 }

--- a/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro/help.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro/help.groovy
@@ -24,6 +24,10 @@ dd() {
     dt("maxTailMatches")
     dd(_("The maximum number of matches to include from the tail of the log. When combined with maxMatches, it further limits the matches to the tail end of matched results. " +
          "If 0, all matches will be included. Defaults to 0."))
+  
+    dt("maxLineLength")
+    dd(_("A maximum length for log lines. When lines are longer than the specified value, they are truncated and a \"...\" marker is appended at the end. " +
+         "If 0, no truncation is done. Defaults to 0."))
 
     dt("showTruncatedLines")
     dd(_("If true, include [...truncated ### lines...] lines. " +

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMacroTest.java
@@ -134,4 +134,26 @@ public class BuildLogMacroTest {
 
         assertEquals("", content);
     }
+
+    @Test
+    public void testGetContent_truncated_with_maxLineLength()
+            throws Exception {
+        buildLogMacro.maxLineLength = 4;
+        when(build.getLog(anyInt())).thenReturn(testLog);
+
+        String content = buildLogMacro.evaluate(build, listener, BuildLogMacro.MACRO_NAME);
+
+        assertEquals("line...\nline...\nline...\n", content);
+    }
+
+    @Test
+    public void testGetContent_untruncated_with_maxLineLength()
+            throws Exception {
+        buildLogMacro.maxLineLength = 6;
+        when(build.getLog(anyInt())).thenReturn(testLog);
+
+        String content = buildLogMacro.evaluate(build, listener, BuildLogMacro.MACRO_NAME);
+
+        assertEquals("line 1\nline 2\nline 3\n", content);
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacroTest.java
@@ -321,6 +321,35 @@ public class BuildLogRegexMacroTest {
                                                                                             "<pre>\n<b>5</b>\n<b>6</b>\n</pre>\n");
     }
 
+    private void testGetContent_line_truncation_with_maxLineLength(String input, String regex, String expectedResult, int maxLineLength)
+            throws Exception {
+        testGetContent_line_truncation_with_maxLineLength(input, regex, expectedResult, maxLineLength, 0, 0);
+    }
+
+    private void testGetContent_line_truncation_with_maxLineLength(String input, String regex, String expectedResult, int maxLineLength, int linesBefore, int linesAfter)
+            throws Exception {
+        when(build.getLogReader()).thenReturn(new StringReader(input));
+        buildLogRegexMacro.linesBefore = linesBefore;
+        buildLogRegexMacro.linesAfter = linesAfter;
+        buildLogRegexMacro.regex = regex;
+        buildLogRegexMacro.maxLineLength = maxLineLength;
+        final String result = buildLogRegexMacro.evaluate(build, listener, BuildLogRegexMacro.MACRO_NAME);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testGetContent_truncated_lines_with_maxLineLength()
+            throws Exception {
+        testGetContent_line_truncation_with_maxLineLength("short line\na longer line\n", ".", "short line\na longer l...\n", 10);
+    }
+
+    @Test
+    public void testGetContent_truncated_context_lines_with_maxLineLength ()
+            throws Exception {
+        testGetContent_line_truncation_with_maxLineLength("ab\n1\nc\n", "\\d", "a...\n1\nc\n", 1, 1, 1);
+    }
+
     @Test
     public void testGetContent_errorMatchedAndNothingReplaced()
             throws Exception {


### PR DESCRIPTION
This change addresses [JENKINS-66018](https://issues.jenkins.io/browse/JENKINS-66018). This adds a new `maxLineLength` parameter for the macros `BUILD_LOG_REGEX` and `BUILD_LOG` that can help email from getting cluttered by very long lines.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
