### PR TITLE
Update json-path version [SECURITY-2607]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.5.0</version>
+      <version>2.6.0</version>
       <exclusions>
         <exclusion> <!-- Note that json-smart *also* bundles ASM 5 inline, which we cannot do anything about. Bad form! -->
           <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
json-path has security vulnerability, fixed by updating the version to 2.6.0.

references:
https://issues.jenkins.io/browse/SECURITY-2607
https://github.com/json-path/JsonPath/issues/676
https://mvnrepository.com/artifact/net.minidev/json-smart/2.3.1
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-27568 

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
