### PR TITLE
Update CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,16 +43,16 @@ jobs:
     if: needs.validate.outputs.should_release == 'true'
     steps:
     - name: Check out
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 8
     - name: Release
-      uses: jenkins-infra/jenkins-maven-cd-action@v1.1.0
+      uses: jenkins-infra/jenkins-maven-cd-action@v1.2.0
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}


### PR DESCRIPTION
Among other things, this upgrades us to a recent version of Java 8 as in https://github.com/jenkinsci/jenkins/pull/6406