### PR TITLE
Add escapeHtml parameter to all DataBoundTokenMacro implementations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMacro.java
@@ -6,7 +6,6 @@ import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.tools.ant.taskdefs.Parallel;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
@@ -31,9 +30,6 @@ public class BuildLogMacro extends DataBoundTokenMacro {
 
     @Parameter
     public int truncTailLines = 0;
-
-    @Parameter
-    public boolean escapeHtml = false;
 
     @Parameter
     public int maxLineLength = MAX_LINE_LENGTH_DEFAULT_VALUE;
@@ -84,5 +80,10 @@ public class BuildLogMacro extends DataBoundTokenMacro {
         }
 
         return buffer.toString();
+    }
+
+    @Override
+    public boolean handlesHtmlEscapeInternally() {
+        return true;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMultilineRegexMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogMultilineRegexMacro.java
@@ -6,7 +6,6 @@ import hudson.console.ConsoleNote;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import org.apache.commons.lang.StringEscapeUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -14,6 +13,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringEscapeUtils;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
@@ -39,8 +40,6 @@ public class BuildLogMultilineRegexMacro extends DataBoundTokenMacro {
     public boolean showTruncatedLines = true;
     @Parameter
     public String substText = null; // insert entire segment
-    @Parameter
-    public boolean escapeHtml = false;
     @Parameter
     public String matchedSegmentHtmlStyle = null;
 
@@ -208,6 +207,11 @@ public class BuildLogMultilineRegexMacro extends DataBoundTokenMacro {
             ++lineTerminatorCount;
         }
         return lineTerminatorCount;
+    }
+
+    @Override
+    public boolean handlesHtmlEscapeInternally() {
+        return true;
     }
 }
 

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacro.java
@@ -53,8 +53,6 @@ public class BuildLogRegexMacro extends DataBoundTokenMacro {
     @Parameter
     public String substText = null; // insert entire line
     @Parameter
-    public boolean escapeHtml = false;
-    @Parameter
     public String matchedLineHtmlStyle = null;
     @Parameter
     public boolean addNewline = true;
@@ -322,5 +320,10 @@ public class BuildLogRegexMacro extends DataBoundTokenMacro {
         Pair(K key, V val) {
             super(key, val);
         }
+    }
+
+    @Override
+    public boolean handlesHtmlEscapeInternally() {
+        return true;
     }
 }

--- a/src/main/resources/lib/token-macro/help.groovy
+++ b/src/main/resources/lib/token-macro/help.groovy
@@ -1,8 +1,18 @@
+import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro
+
 st = namespace("jelly:stapler")
 
 
 org.jenkinsci.plugins.tokenmacro.TokenMacro.all().each { tm ->
     st.include(it:tm, page: "help", optional: true)
+    if (tm instanceof DataBoundTokenMacro && !tm.handlesHtmlEscapeInternally()) {
+        dd() {
+            dl() {
+                dt("escapeHtml")
+                dd(_("If true, any HTML specific code will be escaped. Defaults to false."))
+            }
+        }
+    }
     br()
 }
 

--- a/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/AbstractChangesSinceMacro/help.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/AbstractChangesSinceMacro/help.groovy
@@ -23,6 +23,6 @@ dd {
     }
   }
   span("Following Parameters are also supported: " +
-          "showPaths, pathFormat, showDependencies, dateFormat, regex, replace, default. " +
+          "showPaths, pathFormat, showDependencies, dateFormat, regex, replace, default, escapeHtml. " +
           "See \${CHANGES_SINCE_LAST_BUILD} details.")
 }

--- a/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/JsonFileMacro/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/JsonFileMacro/help.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <dt>$${JSON,file="FILE",path="JSON/PATH",expr="EXPRESSION"}</dt>
+  <dd>
+    Expands to the result(s) of a JSON path or expression run against the given JSON file.<br/>
+    If the path/expr evaluates to more than one value, then a semicolon-separated string is returned.<br/>
+    The file path is relative to the build workspace root.
+  </dd>
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildLogRegexMacroTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.tokenmacro.impl;
 
+import com.google.common.collect.ArrayListMultimap;
 import hudson.console.ConsoleNote;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
@@ -11,6 +12,7 @@ import org.jvnet.hudson.test.Issue;
 
 import java.io.InputStreamReader;
 import java.io.StringReader;
+import java.util.Collections;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -434,6 +436,24 @@ public class BuildLogRegexMacroTest {
         final String result = buildLogRegexMacro.evaluate(build, listener, BuildLogRegexMacro.MACRO_NAME);
 
         assertEquals("<pre>\n<b style=\"color: red\">error</b>\n</pre>\n", result);
+    }
+
+    @Test
+    public void testGetContent_matchedLineHtmlStyleWithHtmlEscape()
+            throws Exception {
+        when(build.getLogReader()).thenReturn(
+                new StringReader("<error>"));
+        final Map<String, String> arguments = new HashMap<>();
+        arguments.put("escapeHtml", "true");
+        arguments.put("showTruncatedLines", "false");
+        arguments.put("matchedLineHtmlStyle", "color: red");
+        final ArrayListMultimap<String, String> listMultimap = ArrayListMultimap.create();
+        listMultimap.put("escapeHtml", "true");
+        listMultimap.put("showTruncatedLines", "false");
+        listMultimap.put("matchedLineHtmlStyle", "color: red");
+        final String result = buildLogRegexMacro.evaluate(build, null, listener, BuildLogRegexMacro.MACRO_NAME, arguments, listMultimap);
+
+        assertEquals("<pre>\n<b style=\"color: red\">&lt;error&gt;</b>\n</pre>\n", result);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacroTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.tokenmacro.impl;
 
+import com.google.common.collect.ArrayListMultimap;
 import hudson.model.AbstractBuild;
 import hudson.model.Result;
 import hudson.model.TaskListener;
@@ -17,10 +18,12 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -183,6 +186,29 @@ public class ChangesSinceLastBuildMacroTest {
         String content = changesSinceLastBuildMacro.evaluate(currentBuild, listener, ChangesSinceLastBuildMacro.MACRO_NAME);
 
         assertEquals("another default message\n", content);
+    }
+
+    @Test
+    public void testShouldDefaultToNotEscapeHtml()
+            throws Exception {
+        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "<b>bold</b>");
+
+        String content = changesSinceLastBuildMacro.evaluate(currentBuild, listener, ChangesSinceLastBuildMacro.MACRO_NAME);
+
+        assertEquals("[Ash Lux] <b>bold</b>\n\n", content);
+    }
+
+    @Test
+    public void testShouldEscapeHtmlWhenArgumentEscapeHtmlSetToTrue()
+            throws Exception {
+        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "<b>bold</b>");
+
+        final Map<String, String> arguments = Collections.singletonMap("escapeHtml", "true");
+        final ArrayListMultimap<String, String> listMultimap = ArrayListMultimap.create();
+        listMultimap.put("escapeHtml", "true");
+        String content = changesSinceLastBuildMacro.evaluate(currentBuild, null, listener, ChangesSinceLastBuildMacro.MACRO_NAME, arguments, listMultimap);
+
+        assertEquals("[Ash Lux] &lt;b&gt;bold&lt;/b&gt;\n\n", content);
     }
 
     private AbstractBuild createBuild(Result result, int buildNumber, String message) {


### PR DESCRIPTION
This adds escapeHtml parameter to all macros extending from `DataBoundTokenMacro` i.e. any macro that takes a parameter. Any HTML content will be escaped with StringEscapeUtils.escapeHtml.
The implementing macro doesn't need to care by default about this parameter, but can do the escaping by itself by overriding `handlesHtmlEscapeInternally` and returning `true`.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
