### PR TITLE
feat: Add BUILD_USER macro which returns the user who caused the build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildUserMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/BuildUserMacro.java
@@ -1,0 +1,45 @@
+package org.jenkinsci.plugins.tokenmacro.impl;
+
+import com.google.common.collect.ListMultimap;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.AbstractBuild;
+import hudson.model.Cause;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Extension
+public class BuildUserMacro extends TokenMacro {
+    public static final String MACRO_NAME = "BUILD_USER";
+
+    @Override
+    public boolean acceptsMacroName(String macroName) {
+        return macroName.equals(MACRO_NAME);
+    }
+
+    @Override
+    public List<String> getAcceptedMacroNames() {
+        return Collections.singletonList(MACRO_NAME);
+    }
+
+    @Override
+    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
+        return evaluate(context,null,listener,macroName,arguments,argumentMultimap);
+    }
+
+    @Override
+    public String evaluate(Run<?, ?> run, FilePath workspace, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap) throws MacroEvaluationException, IOException, InterruptedException {
+        Cause.UserIdCause userIdCause = run.getCause(Cause.UserIdCause.class);
+        if(userIdCause != null) {
+            return userIdCause.getUserId();
+        }
+        return Messages.TokenMacro_Unknown();
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/BuildUserMacro/help.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/BuildUserMacro/help.groovy
@@ -1,0 +1,2 @@
+dt("\${BUILD_USER}")
+dd(_("Displays the user who caused the current build."))

--- a/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tokenmacro/impl/Messages.properties
@@ -1,0 +1,1 @@
+TokenMacro.Unknown=<Unknown>

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildUserMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/BuildUserMacroTest.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.tokenmacro.impl;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Cause;
+import hudson.model.Result;
+import hudson.util.StreamTaskListener;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.WithoutJenkins;
+
+import java.io.StringWriter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({"unchecked"})
+public class BuildUserMacroTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @WithoutJenkins
+    public void testGetContent_BuildUser()
+            throws Exception {
+        AbstractBuild build = mock(AbstractBuild.class);
+        Cause.UserIdCause cause = mock(Cause.UserIdCause.class);
+        when(cause.getUserId()).thenReturn("johndoe");
+        when(build.getCause(Cause.UserIdCause.class)).thenReturn(cause);
+
+        String content = new BuildUserMacro().evaluate(build, StreamTaskListener.fromStdout(), BuildUserMacro.MACRO_NAME, null, null);
+
+        assertEquals("johndoe", content);
+    }
+}


### PR DESCRIPTION
Adds a new macro that will return the username of the user who initiated the build. If a user did not initiate the build, then "<Unknown>" will be returned.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
