### PR TITLE
`workflow-step-api` dep should not be `optional`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <optional>true</optional>
     </dependency>
 
     <!-- Test Deps -->


### PR DESCRIPTION
Dep introduced in 9ab7b0e52c44718ac501576b2087ff8afdfa7bfd and incorrectly made `optional` in #101 without using either `@Extension(optional=true)` nor `@OptionalExtension(plugins="workflow-step-api")`. Causes stack traces in tests of plugins with an `optional` dep on `token-macro` but without otherwise depending on `workflow-step-api`.