### PR TITLE
[JENKINS-71810] Token Macro tests fail on Java 21

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacroTest.java
@@ -21,9 +21,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,8 +74,8 @@ public class ChangesSinceLastBuildMacroTest {
 
         String content = changesSinceLastBuildMacro.evaluate(currentBuild, listener, ChangesSinceLastBuildMacro.MACRO_NAME);
 
-        // Java 9 changed the SHORT date format... https://www.oracle.com/technetwork/java/javase/9-relnote-issues-3704069.html#JDK-8008577
-        assertTrue(content.matches("Oct 21, 2013,? 7:39:00 PM"));
+        // Java 21 changed the SHORT date format... https://bugs.openjdk.org/browse/JDK-8225245
+        assertThat(content, matchesPattern("Oct 21, 2013, 7:39:00\\hPM"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastSuccessfulBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastSuccessfulBuildMacroTest.java
@@ -19,8 +19,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
-import static junit.framework.Assert.assertEquals;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -148,10 +150,10 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
 
         String contentStr = content.evaluate(currentBuild, listener, ChangesSinceLastSuccessfulBuildMacro.MACRO_NAME);
 
-        // Date format changed in Java 9, so we have to accomodate the potential additional comma
-        // See https://www.oracle.com/technetwork/java/javase/9-relnote-issues-3704069.html#JDK-8008577
-        Assert.assertTrue(contentStr.matches(
-                "Changes for Build #41\n" + "Oct 21, 2013,? 7:39:00 PM\n" + "Changes for Build #42\n" + "Oct 21, 2013,? 7:39:00 PM\n"));
+        // Date format changed in Java 21, so we have to accomodate the potential narrow no-break space
+        // See https://bugs.openjdk.org/browse/JDK-8225245
+        assertThat(contentStr, matchesPattern(
+                "Changes for Build #41\n" + "Oct 21, 2013, 7:39:00\\hPM\n" + "Changes for Build #42\n" + "Oct 21, 2013, 7:39:00\\hPM\n"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastUnstableBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastUnstableBuildMacroTest.java
@@ -24,7 +24,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
-import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -151,10 +153,10 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         String contentStr = content.evaluate(currentBuild, listener, ChangesSinceLastUnstableBuildMacro.MACRO_NAME);
 
-        // Date format changed in Java 9, so we have to accomodate the potential additional comma
-        // See https://www.oracle.com/technetwork/java/javase/9-relnote-issues-3704069.html#JDK-8008577
-        Assert.assertTrue(contentStr.matches(
-                "Changes for Build #41\n" + "Oct 21, 2013,? 7:39:00 PM\n" + "Changes for Build #42\n" + "Oct 21, 2013,? 7:39:00 PM\n"));
+        // Date format changed in Java 21, so we have to accomodate the potential narrow no-break space
+        // See https://bugs.openjdk.org/browse/JDK-8225245
+        assertThat(contentStr, matchesPattern(
+                "Changes for Build #41\n" + "Oct 21, 2013, 7:39:00\\hPM\n" + "Changes for Build #42\n" + "Oct 21, 2013, 7:39:00\\hPM\n"));
     }
 
     @Test


### PR DESCRIPTION
See [JENKINS-71810](https://issues.jenkins.io/browse/JENKINS-71810). Java 21 changed the date format to use a narrow no-break space, so the regular expression used in the tests now fails to match. Changed the test to use the `\h` character class, which matches

> A horizontal whitespace character: `[ \t\xA0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000]`

### Testing done

Ran the tests on Java 11, 17, and 21. Before this PR, Java 21 failed. After this PR, all Java versions are passing.

### Bonus

While I was here, I updated the test to use Hamcrest matchers for a more readable error message if the test fails.