### PR TITLE
Removed 11 unnecessary stubbings in ChangesSinceLastSuccessfulBuildMacroTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastSuccessfulBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastSuccessfulBuildMacroTest.java
@@ -53,7 +53,7 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
             throws Exception {
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild3(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -76,9 +76,8 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild3(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
-        when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
         String contentStr = content.evaluate(currentBuild, listener, ChangesSinceLastSuccessfulBuildMacro.MACRO_NAME);
 
@@ -91,11 +90,10 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
             throws Exception {
         // Test for HUDSON-3519
 
-        AbstractBuild successfulBuild = createBuild(Result.SUCCESS, 2, "Changes for a successful build.");
+        AbstractBuild successfulBuild = createBuild2(Result.SUCCESS, 2, "Changes for a successful build.");
 
         AbstractBuild unstableBuild = createBuild(Result.UNSTABLE, 3, "Changes for an unstable build.");
         when(unstableBuild.getPreviousBuild()).thenReturn(successfulBuild);
-        when(successfulBuild.getNextBuild()).thenReturn(unstableBuild);
 
         AbstractBuild abortedBuild = createBuild(Result.ABORTED, 4, "Changes for an aborted build.");
         when(abortedBuild.getPreviousBuild()).thenReturn(unstableBuild);
@@ -109,7 +107,7 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
         when(notBuiltBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(notBuiltBuild);
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 7, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild3(Result.SUCCESS, 7, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(notBuiltBuild);
         when(notBuiltBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -144,7 +142,7 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild3(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -162,7 +160,7 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
         content.changesFormat = "%r";
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild3(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -177,7 +175,7 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
         content.changesFormat = "%p";
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild3(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -193,7 +191,7 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild3(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -213,7 +211,7 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "<defectId>DEFECT-666</defectId><message>Changes for a failed build.</message>");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "<defectId>DEFECT-666</defectId><message>Changes for a successful build.</message>");
+        AbstractBuild currentBuild = createBuild3(Result.SUCCESS, 42, "<defectId>DEFECT-666</defectId><message>Changes for a successful build.</message>");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -336,9 +334,7 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
 
     private AbstractBuild createBuildWithNoChanges(Result result, int buildNumber) {
         AbstractBuild build = mock(AbstractBuild.class);
-        when(build.getResult()).thenReturn(result);
         ChangeLogSet changes1 = createEmptyChangeLog();
-        when(build.getChangeSet()).thenReturn(changes1);
         when(build.getChangeSets()).thenReturn(Collections.singletonList(changes1));
         when(build.getNumber()).thenReturn(buildNumber);
         return build;
@@ -346,7 +342,6 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
 
     private AbstractBuild createBuildWithNoChangeSets(Result result, int buildNumber) {
         AbstractBuild build = mock(AbstractBuild.class);
-        when(build.getResult()).thenReturn(result);
         when(build.getChangeSets()).thenReturn(Collections.EMPTY_LIST);
         when(build.getNumber()).thenReturn(buildNumber);
 
@@ -367,7 +362,6 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
     public ChangeLogSet createEmptyChangeLog() {
         ChangeLogSet changes = mock(ChangeLogSet.class);
         List<ChangeLogSet.Entry> entries = Collections.emptyList();
-        when(changes.iterator()).thenReturn(entries.iterator());
         when(changes.isEmptySet()).thenReturn(true);
 
         return changes;
@@ -428,5 +422,28 @@ public class ChangesSinceLastSuccessfulBuildMacroTest {
             // 10/21/13 7:39 PM
             return 1382409540000L;
         }
+    }
+
+    public ChangeLogSet createChangeLog2(String message) {
+        ChangeLogSet changes = mock(ChangeLogSet.class);
+        List<ChangeLogSet.Entry> entries = new LinkedList<ChangeLogSet.Entry>();
+        ChangeLogSet.Entry entry = new ChangeLogEntry(message, "Ash Lux");
+        entries.add(entry);
+        return changes;
+    }
+
+    private AbstractBuild createBuild2(Result result, int buildNumber, String message) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        ChangeLogSet changes1 = createChangeLog2(message);
+        when(build.getResult()).thenReturn(result);
+        return build;
+    }
+
+    private AbstractBuild createBuild3(Result result, int buildNumber, String message) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        ChangeLogSet changes1 = createChangeLog(message);
+        when(build.getChangeSets()).thenReturn(Collections.singletonList(changes1));
+        when(build.getNumber()).thenReturn(buildNumber);
+        return build;
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
In our analysis of the project, we observed that 
1)  3 unnecessary stubbings which stubbed `getChangeSet` method, `getChangeSets` method, and `getNumber` method in `ChangesSinceLastSuccessfulBuildMacroTest.createBuild` are created but are only executed by some of the method calls in the test `ChangesSinceLastSuccessfulBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentSuccessful_HUDSON3519`. We duplicated the `createBuild` method, removed the unnecessary stubbings, named it `createBuild2`, and applied the new method to the method call which does not execute the stubbings in the test.

2) 2 unnecessary stubbings which stubbed `getResult` method, `getChangeSet` method in `ChangesSinceLastSuccessfulBuildMacroTest.createBuildWithAffectedFiles` are  are only executed by some of the method calls in 8 tests: `ChangesSinceLastSuccessfulBuildMacroTest.testGetContent_shouldGetPreviousBuildFailures`, `ChangesSinceLastSuccessfulBuildMacroTest.testGetContent_whenReverseOrderIsTrueShouldReverseOrderOfChanges`, `ChangesSinceLastSuccessfulBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentSuccessful_HUDSON3519`, `ChangesSinceLastSuccessfulBuildMacroTest.testShouldPrintDate`,
`ChangesSinceLastSuccessfulBuildMacroTest.testShouldPrintRevision`, `ChangesSinceLastSuccessfulBuildMacroTest.testShouldPrintPath`,
`ChangesSinceLastSuccessfulBuildMacroTest.testWhenShowPathsIsTrueShouldPrintPath`, `ChangesSinceLastSuccessfulBuildMacroTest.testRegexReplace`;
We duplicated the `createBuild` method, removed the unnecessary stubbings, named it `createBuild3`, and applied the new method to the method call which does not execute the stubbings in the test.

3) 1 unnecessary stubbing which stubbed `getResult` method in `ChangesSinceLastSuccessfulBuildMacroTest.createBuildWithNoChangeSets` is created but is never executed. We removed it.

4) 2 unnecessary stubbings which stubbed `getResult` method, `getChangeSet` method in `ChangesSinceLastSuccessfulBuildMacroTest.createBuildWithNoChanges` are created but are never executed. WE removed them

5) 1 unnecessary stubbing which stubbed `iterator` method in `ChangesSinceLastSuccessfulBuildMacroTest.createChangeLog` is created but is only executed by some of the method calls in the test `ChangesSinceLastSuccessfulBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentSuccessful_HUDSON3519`.We duplicated the method, removed the unnecessary stubbings from the new duplicated method, named it `createChangeLog2`, and applied to the specific method call that doesn't execute the stubbing.

6) 1 unnecessary stubbing which stubbed `iterator` method in `ChangesSinceLastSuccessfulBuildMacroTest.createBuildWithAffectedFiles.createEmptyChangeLog` is created but is never executed. We removed it.

7) 1 unnecessary stubbing in the test 'ChangesSinceLastSuccessfulBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentSuccessful_HUDSON3519' is created but never executed. We removed it.

8) 1 unnecessary stubbing in the test 'ChangesSinceLastSuccessfulBuildMacroTest. testGetContent_whenReverseOrderIsTrueShouldReverseOrderOfChanges' is created but never executed. We removed it.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.
<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
