### PR TITLE
Removed 12 unnecessary stubbings in ChangesSinceLastUnstableBuildMacr…

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastUnstableBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastUnstableBuildMacroTest.java
@@ -59,7 +59,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
             throws Exception {
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -82,10 +82,9 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
-        when(failureBuild.getNextBuild()).thenReturn(currentBuild);
-
+        
         String contentStr = content.evaluate(currentBuild, listener, ChangesSinceLastUnstableBuildMacro.MACRO_NAME);
 
         assertEquals("Changes for Build #42\n" + "[Ash Lux] Changes for a successful build.\n" + "\n" + "\n"
@@ -97,15 +96,12 @@ public class ChangesSinceLastUnstableBuildMacroTest {
             throws Exception {
         // Test for HUDSON-3519
 
-        AbstractBuild successfulBuild = createBuild(Result.SUCCESS, 2, "Changes for a successful build.");
+        AbstractBuild successfulBuild = createBuild3(Result.SUCCESS, 2, "Changes for a successful build.");
 
-        AbstractBuild unstableBuild = createBuild(Result.UNSTABLE, 3, "Changes for an unstable build.");
-        when(unstableBuild.getPreviousBuild()).thenReturn(successfulBuild);
-        when(successfulBuild.getNextBuild()).thenReturn(unstableBuild);
+        AbstractBuild unstableBuild = createBuild2(Result.UNSTABLE, 3, "Changes for an unstable build.");
 
         AbstractBuild abortedBuild = createBuild(Result.ABORTED, 4, "Changes for an aborted build.");
         when(abortedBuild.getPreviousBuild()).thenReturn(unstableBuild);
-        when(unstableBuild.getNextBuild()).thenReturn(abortedBuild);
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 5, "Changes for a failed build.");
         when(failureBuild.getPreviousBuild()).thenReturn(abortedBuild);
@@ -115,7 +111,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
         when(notBuiltBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(notBuiltBuild);
 
-        AbstractBuild currentBuild = createBuild(Result.UNSTABLE, 7, "Changes for an unstable build.");
+        AbstractBuild currentBuild = createBuild4(Result.UNSTABLE, 7, "Changes for an unstable build.");
         when(currentBuild.getPreviousBuild()).thenReturn(notBuiltBuild);
         when(notBuiltBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -147,7 +143,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -166,7 +162,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -182,7 +178,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -199,7 +195,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -219,7 +215,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "<defectId>DEFECT-666</defectId><message>Changes for a failed build.</message>");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "<defectId>DEFECT-666</defectId><message>Changes for a successful build.</message>");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "<defectId>DEFECT-666</defectId><message>Changes for a successful build.</message>");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -321,9 +317,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
     
     private AbstractBuild createBuildWithNoChanges(Result result, int buildNumber) {
         AbstractBuild build = mock(AbstractBuild.class);
-        when(build.getResult()).thenReturn(result);
         ChangeLogSet changes1 = createEmptyChangeLog();
-        when(build.getChangeSet()).thenReturn(changes1);
         when(build.getChangeSets()).thenReturn(Collections.singletonList(changes1));
         when(build.getNumber()).thenReturn(buildNumber);
 
@@ -333,7 +327,6 @@ public class ChangesSinceLastUnstableBuildMacroTest {
     public ChangeLogSet createEmptyChangeLog() {
         ChangeLogSet changes = mock(ChangeLogSet.class);
         List<ChangeLogSet.Entry> entries = Collections.emptyList();
-        when(changes.iterator()).thenReturn(entries.iterator());
         when(changes.isEmptySet()).thenReturn(true);
 
         return changes;
@@ -405,5 +398,34 @@ public class ChangesSinceLastUnstableBuildMacroTest {
             // 10/21/13 7:39 PM
             return 1382409540000L;
         }
+    }
+
+    private AbstractBuild createBuild2(Result result, int buildNumber, String message) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        ChangeLogSet changes1 = createChangeLog2(message);
+        when(build.getResult()).thenReturn(result);
+        return build;
+    }
+
+    private AbstractBuild createBuild3(Result result, int buildNumber, String message) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        ChangeLogSet changes1 = createChangeLog2(message);
+        return build;
+    }
+
+    private AbstractBuild createBuild4(Result result, int buildNumber, String message) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        ChangeLogSet changes1 = createChangeLog(message);
+        when(build.getChangeSets()).thenReturn(Collections.singletonList(changes1));
+        when(build.getNumber()).thenReturn(buildNumber);
+        return build;
+    }
+
+    public ChangeLogSet createChangeLog2(String message) {
+        ChangeLogSet changes = mock(ChangeLogSet.class);
+        List<ChangeLogSet.Entry> entries = new LinkedList<ChangeLogSet.Entry>();
+        ChangeLogSet.Entry entry = new ChangeLogEntry(message, "Ash Lux");
+        entries.add(entry);
+        return changes;
     }
 }


### PR DESCRIPTION
…oTest.java

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
In our analysis of the project, we observed that 
1)  3 unnecessary stubbings which stubbed `getChangeSet` method, `getChangeSets` method, and `getNumber` method in `ChangesSinceLastUnstableBuildMacroTest.createBuild` are created but are only executed by some of the method calls in the test `ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentUnstable_HUDSON3519`, We duplicated the `createBuild` method, removed the unnecessary stubbings, named it `createBuild2`, and applied the new method to the method call which does not execute the stubbings in the test.

2)  4 unnecessary stubbings which stubbed `getResult` method, `getChangeSet` method, `getChangeSets` method, and `getNumber` method in `ChangesSinceLastUnstableBuildMacroTest.createBuild` are created but are not executed by the test `ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentUnstable_HUDSON3519`, We duplicated the `createBuild` method, removed the unnecessary stubbings, named it `createBuild3`, and applied the new method to the method call which does not execute the stubbings in the test.

3) 2 unnecessary stubbings which stubbed `getResult` method, `getChangeSet` method in `ChangesSinceLastUnstableBuildMacroTest.createBuildWithAffectedFiles` are created but are are only executed by some of the method calls in 8 tests: `ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildFailures`, `ChangesSinceLastUnstableBuildMacroTest.testGetContent_whenReverseOrderIsTrueShouldReverseOrderOfChanges`, `ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentUnstable_HUDSON3519`, `ChangesSinceLastUnstableBuildMacroTest.testShouldPrintDate`,
`ChangesSinceLastUnstableBuildMacroTest.testShouldPrintRevision`, `ChangesSinceLastUnstableBuildMacroTest.testShouldPrintPath`,
`ChangesSinceLastUnstableBuildMacroTest.testWhenShowPathsIsTrueShouldPrintPath`, `ChangesSinceLastUnstableBuildMacroTest.testRegexReplace`; We duplicated the `createBuild` method, removed the unnecessary stubbings, named it `createBuild4`, and applied the new method to the method call which does not execute the stubbings in the test.

4) 1 unnecessary stubbings which stubbed `getResult` method, `getChangeSet` method in `ChangesSinceLastUnstableBuildMacroTest.createBuildWithNoChanges` are created but are never executed. We removed it.

5) 1 unnecessary stubbing which stubbed `iterator` method in `ChangesSinceLastUnstableBuildMacroTest.createChangeLog` is created but is only executed by some specific method calls in the test `ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentUnstable_HUDSON3519`. We duplicated the method, removed the unnecessary stubbings from the new duplicated method, named it `createChangeLog2`, and applied to the specific method call that doesn't execute the stubbing. We removed it.

6) 1 unnecessary stubbing which stubbed `iterator` method in `ChangesSinceLastUnstableBuildMacroTest.createBuildWithAffectedFiles.createEmptyChangeLog` is created but is never executed. We removed it.

7) 3 unnecessary stubbings in the test 'ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentUnstable_HUDSON3519' are created but are never executed. We removed them.

8) 1 unnecessary stubbing in the test 'ChangesSinceLastUnstableBuildMacroTest. whenReverseOrderIsTrueShouldReverseOrderOfChanges' is created but is never executed. We removed it.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.
<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
