### PR TITLE
Test faster on ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 buildPlugin(
+   forkCount: '1C',
    useContainerAgent: true,
    configurations: [
       [platform: 'linux', jdk: 11],


### PR DESCRIPTION
## Test faster on ci.jenkins.io

Run tests in parallel on ci.jenkins.io to reduce costs and save time.  Tests in parallel on my machine reduce test execution time from over 2.5 minutes to 45 seconds.  On ci.jenkins.io, a test run completed the maven build on Linux in 2.5 minutes when running without parallel tests required over 5 minutes.

### Testing done

Confirmed tests pass and run faster on ci.jenkins.io when forkCount is '1C'.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
