### PR TITLE
Suppress warnings for spotbugs 4.8.3

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/AbstractChangesSinceMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/AbstractChangesSinceMacro.java
@@ -4,6 +4,7 @@ import hudson.FilePath;
 import hudson.model.*;
 import java.io.IOException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
@@ -16,12 +17,14 @@ abstract public class AbstractChangesSinceMacro
     @Parameter
     public boolean reverse = false;
     @Parameter
+    @SuppressFBWarnings(value="PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification="Retain API compatibility.")
     public String format;
     @Parameter
     public boolean showPaths = false;
     @Parameter
     public String changesFormat;
     @Parameter
+    @SuppressFBWarnings(value="PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification="Retain API compatibility.")
     public String pathFormat = "\\t%p\\n";
     @Parameter
     public boolean showDependencies = false;

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacro.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.tokenmacro.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
@@ -37,8 +38,10 @@ public class ChangesSinceLastBuildMacro extends DataBoundTokenMacro {
     @Parameter
     public boolean showPaths = false;
     @Parameter
+    @SuppressFBWarnings(value="PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification="Retain API compatibility.")
     public String format;
     @Parameter
+    @SuppressFBWarnings(value="PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification="Retain API compatibility.")
     public String pathFormat = PATH_FORMAT_DEFAULT_VALUE;
     @Parameter
     public boolean showDependencies = false;

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/JsonFileMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/JsonFileMacro.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.tokenmacro.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import hudson.Extension;
@@ -40,6 +41,7 @@ public class JsonFileMacro extends DataBoundTokenMacro {
     public String file = null;
 
     @Parameter
+    @SuppressFBWarnings(value="PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification="Retain API compatibility.")
     public String path = null;
 
     @Parameter

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/WorkspaceFileMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/WorkspaceFileMacro.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.tokenmacro.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -49,6 +50,7 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 @Extension
 public class WorkspaceFileMacro extends DataBoundTokenMacro  {
     @Parameter(required=true)
+    @SuppressFBWarnings(value="PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification="Retain API compatibility.")
     public String path = "";
     @Parameter
     public String fileNotFoundMessage = "ERROR: File '%s' does not exist";


### PR DESCRIPTION
## Suppress warnings for spotbugs 4.8.3

https://github.com/jenkinsci/plugin-pom/pull/869 or a subsequent pull request that updates to 4.8.3 will need this change in the plugin to resolve new spotbugs warnings that will be reported by spotbugs 4.8.2 and later.

Plugin pom 4.77 is likely to include that new version of spotbugs.

### Testing done

Confirmed that the spotbugs warnings are visible when using the 4.77-SNAPSHOT plugin pom before this change. With this change, the spotbugs warnings are no longer visible.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
