### PR TITLE
Allow missing FilePath when expanding macros

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/Parser.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/Parser.java
@@ -2,6 +2,8 @@ package org.jenkinsci.plugins.tokenmacro;
 
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
@@ -28,7 +30,7 @@ public class Parser {
     private StringBuilder output;
 
     private Run<?, ?> run;
-    private FilePath workspace;
+    private @CheckForNull FilePath workspace;
     private TaskListener listener;
     private boolean throwException;
     private String stringWithMacro;
@@ -40,7 +42,7 @@ public class Parser {
     private String tokenName;
     private ListMultimap<String,String> args;
 
-    public Parser(Run<?,?> run, FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException) {
+    public Parser(Run<?,?> run, @CheckForNull FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException) {
         this.run = run;
         this.workspace = workspace;
         this.listener = listener;
@@ -50,7 +52,7 @@ public class Parser {
         this.recursionLevel = 0;
     }
 
-    public Parser(Run<?,?> run, FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException, int recursionLevel) {
+    public Parser(Run<?,?> run, @CheckForNull FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException, int recursionLevel) {
         this.run = run;
         this.workspace = workspace;
         this.listener = listener;
@@ -64,11 +66,11 @@ public class Parser {
         return process(build,build.getWorkspace(),listener,stringWithMacro,throwException,privateTokens);
     }
 
-    public static String process(Run<?, ?> run, FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException, List<TokenMacro> privateTokens) throws MacroEvaluationException {
+    public static String process(Run<?, ?> run, @CheckForNull FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException, List<TokenMacro> privateTokens) throws MacroEvaluationException {
         return process(run, workspace, listener, stringWithMacro, throwException, privateTokens, 0);
     }
 
-    private static String process(Run<?,?> run, FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException, List<TokenMacro> privateTokens, int recursionLevel) throws MacroEvaluationException {
+    private static String process(Run<?,?> run, @CheckForNull FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException, List<TokenMacro> privateTokens, int recursionLevel) throws MacroEvaluationException {
         if ( StringUtils.isBlank( stringWithMacro ) ) return stringWithMacro;
 
         Parser p = new Parser(run, workspace, listener, stringWithMacro, throwException);

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/TokenMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/TokenMacro.java
@@ -131,7 +131,7 @@ public abstract class TokenMacro implements ExtensionPoint {
     public abstract String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap)
             throws MacroEvaluationException, IOException, InterruptedException;
 
-    public String evaluate(Run<?, ?> run, FilePath workspace, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap)
+    public String evaluate(Run<?, ?> run, @CheckForNull FilePath workspace, TaskListener listener, String macroName, Map<String, String> arguments, ListMultimap<String, String> argumentMultimap)
             throws MacroEvaluationException, IOException, InterruptedException
     {
         return macroName + " is not supported in this context";
@@ -188,11 +188,11 @@ public abstract class TokenMacro implements ExtensionPoint {
         return Parser.process(context,listener,stringWithMacro,throwException,privateTokens);
     }
 
-    public static String expand(Run<?, ?> run, FilePath workspace, TaskListener listener, String stringWithMacro) throws MacroEvaluationException, IOException, InterruptedException {
+    public static String expand(Run<?, ?> run, @CheckForNull FilePath workspace, TaskListener listener, String stringWithMacro) throws MacroEvaluationException, IOException, InterruptedException {
         return expand(run, workspace, listener, stringWithMacro, true, null);
     }
 
-    public static String expand(Run<?, ?> run, FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException, List<TokenMacro> privateTokens) throws MacroEvaluationException, IOException, InterruptedException {
+    public static String expand(Run<?, ?> run, @CheckForNull FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException, List<TokenMacro> privateTokens) throws MacroEvaluationException, IOException, InterruptedException {
         return Parser.process(run,workspace,listener,stringWithMacro,throwException,privateTokens);
     }
 
@@ -200,7 +200,7 @@ public abstract class TokenMacro implements ExtensionPoint {
         return expandAll(context,listener,stringWithMacro,true,null);
     }
 
-    public static String expandAll(Run<?,?> run, FilePath workspace, TaskListener listener, String stringWithMacro) throws MacroEvaluationException, IOException, InterruptedException {
+    public static String expandAll(Run<?,?> run, @CheckForNull FilePath workspace, TaskListener listener, String stringWithMacro) throws MacroEvaluationException, IOException, InterruptedException {
         return expandAll(run,workspace,listener,stringWithMacro,true,null);
     }
 
@@ -208,7 +208,7 @@ public abstract class TokenMacro implements ExtensionPoint {
         return expandAll(context,getWorkspace(context),listener,stringWithMacro,throwException,privateTokens);
     }
 
-    public static String expandAll(Run<?,?> run, FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException, List<TokenMacro> privateTokens) throws MacroEvaluationException, IOException, InterruptedException {
+    public static String expandAll(Run<?,?> run, @CheckForNull FilePath workspace, TaskListener listener, String stringWithMacro, boolean throwException, List<TokenMacro> privateTokens) throws MacroEvaluationException, IOException, InterruptedException {
         // Do nothing for an empty String
         if (stringWithMacro==null || stringWithMacro.length()==0) return stringWithMacro;
 

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/TokenMacroStep.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/TokenMacroStep.java
@@ -58,7 +58,7 @@ public class TokenMacroStep extends Step {
 
         @Override public Set<? extends Class<?>> getRequiredContext() {
             Set<Class<?>> context = new HashSet<>();
-            Collections.addAll(context, Run.class, FilePath.class, TaskListener.class);
+            Collections.addAll(context, Run.class, TaskListener.class);
             return Collections.unmodifiableSet(context);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/WorkspaceDependentMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/WorkspaceDependentMacro.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.tokenmacro;
+
+import java.io.IOException;
+import hudson.remoting.Callable;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.FilePath;
+import hudson.model.AbstractBuild;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+public abstract class WorkspaceDependentMacro extends DataBoundTokenMacro {
+
+	@Override
+	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
+		return evaluate(context, context.getWorkspace(), listener, macroName);
+	}
+
+	@Override
+	public String evaluate(Run<?,?> run, @CheckForNull FilePath workspace, TaskListener listener, String macroName)  throws MacroEvaluationException, IOException, InterruptedException {
+		if (workspace == null) {
+			throw new MacroEvaluationException("Macro '" + macroName
+					+ "' can ony be evaluated in a workspace.");
+		}
+
+		String root = workspace.getRemote();
+		return workspace.act(getCallable(run, root, listener));
+	}
+
+	public abstract Callable<String, IOException> getCallable(Run<?,?> run, String root, TaskListener listener);
+
+	@Override
+	public boolean acceptsMacroName(String macroName) {
+		return getAcceptedMacroNames().contains(macroName);
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/PropertyFromFileMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/PropertyFromFileMacro.java
@@ -1,13 +1,14 @@
 package org.jenkinsci.plugins.tokenmacro.impl;
 
 import hudson.Extension;
-import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.remoting.Callable;
 import jenkins.security.MasterToSlaveCallable;
-import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
+
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.plugins.tokenmacro.WorkspaceDependentMacro;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -19,7 +20,7 @@ import java.util.Properties;
  * Expands to a property from a property file relative to the workspace root.
  */
 @Extension
-public class PropertyFromFileMacro extends DataBoundTokenMacro {
+public class PropertyFromFileMacro extends WorkspaceDependentMacro {
 
     private static final String MACRO_NAME = "PROPFILE";
 
@@ -45,9 +46,8 @@ public class PropertyFromFileMacro extends DataBoundTokenMacro {
     }
 
     @Override
-    public String evaluate(Run<?,?> run, FilePath workspace, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
-        String root = workspace.getRemote();
-        return workspace.act(new ReadProperty(root, file, property));
+    public Callable<String, IOException> getCallable(Run<?,?> run, String root, TaskListener listener) {
+        return new ReadProperty(root, file, property);
     }
 
     private static class ReadProperty extends MasterToSlaveCallable<String,IOException> {

--- a/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/XmlFileMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/tokenmacro/impl/XmlFileMacro.java
@@ -1,16 +1,12 @@
 package org.jenkinsci.plugins.tokenmacro.impl;
 
 import hudson.Extension;
-import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.Callable;
-import java.io.Closeable;
-import java.io.Reader;
-import java.io.BufferedReader;
+
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Collections;
@@ -21,6 +17,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import jenkins.security.MasterToSlaveCallable;
+
+import org.jenkinsci.plugins.tokenmacro.WorkspaceDependentMacro;
 import org.w3c.dom.*;
 
 import javax.xml.XMLConstants;
@@ -30,7 +28,6 @@ import javax.xml.parsers.*;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 /**
@@ -38,7 +35,7 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
  * If xpath evaluates to more than one value then a semicolon separted string is returned.
  */
 @Extension
-public class XmlFileMacro extends DataBoundTokenMacro {
+public class XmlFileMacro extends WorkspaceDependentMacro {
 
     public static final Logger LOGGER = Logger.getLogger(XmlFileMacro.class.getName());
     
@@ -66,9 +63,8 @@ public class XmlFileMacro extends DataBoundTokenMacro {
     }
 
     @Override
-    public String evaluate(Run<?,?> run, FilePath workspace, TaskListener listener, String macroName)  throws MacroEvaluationException, IOException, InterruptedException {
-        String root = workspace.getRemote();
-        return workspace.act(new ReadXML(root,file,xpath));
+    public Callable<String, IOException> getCallable(Run<?,?> run, String root, TaskListener listener) {
+        return new ReadXML(root, file, xpath);
     }
 
     private static class ReadXML extends MasterToSlaveCallable<String, IOException> {


### PR DESCRIPTION
Sometimes it's useful to run the `tm` step even if there is no active node/workspace. Instead of checking that FilePath is present upfront, check it only while expanding a macro that needs it.

### Testing done

Checked that the Build Failure Analyzer macro expands properly after all connections to nodes are stopped.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

